### PR TITLE
docs: Claude Code project settings and workflow rules

### DIFF
--- a/.claude/rules/mcp-tools.md
+++ b/.claude/rules/mcp-tools.md
@@ -1,0 +1,37 @@
+# MCP Tools Reference
+
+11 tools defined in `core/src/mcp.ts`, served via both stdio and HTTP transports.
+
+## Tool List
+
+| Tool | Purpose | Key Params |
+|------|---------|------------|
+| `create-note` | Create note with tags | `content`, `tags[]`, `path` |
+| `update-note` | Update content or path | `id`, `content`, `path` |
+| `delete-note` | Delete note + tags + links | `id` |
+| `read-notes` | Query by tags, dates, pagination | `tags[]`, `exclude_tags[]`, `date_from` (inclusive), `date_to` (exclusive), `limit`, `offset` |
+| `search-notes` | Full-text search (FTS5) | `query`, `tags[]`, `limit` |
+| `tag-note` | Add tags to a note | `id`, `tags[]` |
+| `untag-note` | Remove tags from a note | `id`, `tags[]` |
+| `create-link` | Link two notes | `source_id`, `target_id`, `relationship` |
+| `delete-link` | Remove a link | `source_id`, `target_id`, `relationship` |
+| `get-links` | Get note's connections | `id`, `direction` (outbound/inbound/both) |
+| `list-tags` | All tags with counts | (none) |
+
+## Date Range Semantics
+
+- `date_from`: inclusive (`>=`)
+- `date_to`: exclusive (`<`)
+- To get all of March: `date_from: "2026-03-01"`, `date_to: "2026-04-01"`
+
+## Transports
+
+- **HTTP**: `POST /mcp` on the Hono server (port 1940), session-based
+- **stdio**: `npx tsx src/mcp-stdio.ts`, for direct Claude integration
+
+## When Modifying Tools
+
+- Tools are defined in `core/src/mcp.ts` using plain JSON Schema (not Zod)
+- `QueryOpts` type in `core/src/types.ts` — add new params there first
+- Store layer in `core/src/notes.ts` — implement the query logic
+- Run `cd core && npm test` — tool registration is tested

--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -1,0 +1,27 @@
+# Security Rules
+
+## Sensitive Files — Never Read or Edit
+
+- `~/.parachute/server.yaml` — contains hashed API keys
+- `.env`, `.env.*` — environment secrets
+- Any file matching `*credentials*`, `*secret*`
+
+## API Keys
+
+- Never log, print, or include API keys in commits
+- Keys are generated via `POST /api/auth/keys` (localhost only)
+- Format: `para_<32 chars>`, ID: `k_<12 chars>`
+- Stored as SHA-256 hashes in server.yaml
+
+## Auth Model
+
+- `remote` mode (default): localhost bypasses auth, remote requires API key
+- `always` mode: all requests need a key
+- `disabled` mode: dev only, never in production
+- Auth header: `Authorization: Bearer para_...` or `X-API-Key: para_...`
+
+## When Touching Auth Code
+
+- Never weaken auth checks (e.g., removing isLocalhost guards)
+- Timing-safe comparison for key verification (crypto.timingSafeEqual)
+- Config file permissions: 0o600 (owner read/write only)

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,23 @@
+# Testing Rules
+
+## Test Suites
+
+| Package | Command | Count | Time |
+|---------|---------|-------|------|
+| core | `cd core && npm test` | 39 | ~1s |
+| local | `cd local && npm test` | 22 | ~1s |
+| app | `cd app && flutter analyze` | static | ~5s |
+
+## When to Run Tests
+
+- **Always** before committing (all three suites)
+- After modifying `core/src/` — run core tests
+- After modifying `local/src/` — run both core and local tests (local depends on core)
+- After modifying `app/lib/` — run flutter analyze
+- After modifying MCP tools — run core tests (tools are tested there)
+
+## Test Patterns
+
+- Core tests use in-memory SQLite (`:memory:`) — no fixtures to manage
+- Local tests use supertest against the Hono app
+- Flutter uses `flutter analyze` for static analysis; integration tests exist but run manually on macOS

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -1,0 +1,39 @@
+# Development Workflow
+
+## Branching
+
+- Create a feature branch for every change: `feature/*`, `fix/*`, `docs/*`
+- Open a PR with a summary even for self-merge — creates a paper trail
+- Squash-merge to keep main clean
+
+## Before Committing
+
+Always run the full validation suite before committing:
+
+```bash
+cd core && npm test          # 39 tests, ~1s
+cd ../local && npm test      # 22 tests, ~1s
+cd ../app && flutter analyze # static analysis, ~5s
+```
+
+If any check fails, fix before committing. No exceptions.
+
+## Commit Messages
+
+Follow conventional commits: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`
+
+Keep the first line under 72 characters. Add a body for non-trivial changes explaining *why*, not *what*.
+
+## Deploying to Device
+
+Don't deploy mid-debug. The workflow is:
+1. Make changes
+2. Run tests
+3. Commit to branch
+4. Build and deploy APK
+5. Test on device
+6. If broken, fix on the branch — don't iterate APK installs without commits
+
+## PRs
+
+Use `gh pr create` with a summary. Include a test plan.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,24 @@
+{
+  "permissions": {
+    "deny": [
+      "Read(~/.parachute/server.yaml)",
+      "Read(**/.env*)",
+      "Edit(**/.env*)",
+      "Edit(~/.parachute/server.yaml)",
+      "Write(**/.env*)"
+    ]
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "file=\"$(echo $TOOL_INPUT | jq -r '.file_path // empty')\" && case \"$file\" in *.ts|*.tsx|*.js|*.mjs) cd /Users/parachute/Code/parachute-daily && npx prettier --write \"$file\" 2>/dev/null ;; esac; exit 0"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ dist/
 *.db
 *.db-wal
 *.db-shm
+
+# Claude Code local settings (machine-specific permissions, not shared)
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,8 @@ Tags use optional `/` hierarchy by convention: `#doc/meeting`, `#doc/draft`. Pre
 
 `create-note`, `update-note`, `delete-note`, `read-notes`, `search-notes`, `tag-note`, `untag-note`, `create-link`, `delete-link`, `get-links`, `list-tags`
 
+See `.claude/rules/mcp-tools.md` for detailed params and date range semantics.
+
 ## Running
 
 ```bash
@@ -57,6 +59,10 @@ cd core && npm test    # 39 tests
 cd local && npm test   # 22 tests
 cd app && flutter analyze
 ```
+
+## Workflow
+
+Feature branches + PRs for all changes. Run all tests before committing. See `.claude/rules/workflow.md`.
 
 ## Architecture
 


### PR DESCRIPTION
## Summary

- Adds `.claude/settings.json` with permission deny list (sensitive files) and PostToolUse hook to auto-format TypeScript with prettier on edits
- Creates `.claude/rules/` with four scoped rule files: workflow, testing, security, MCP tools
- Updates `.gitignore` to exclude `settings.local.json` (machine-specific)
- Adds workflow section to root `CLAUDE.md`

## What this enforces

| Practice | Mechanism |
|----------|-----------|
| Can't read/edit `.env` or `server.yaml` | Permission deny list |
| TypeScript auto-formatted on save | PostToolUse hook (prettier) |
| Feature branches + PRs | Documented in workflow rules |
| Tests before every commit | Documented in testing rules |
| No deploying mid-debug | Documented in workflow rules |
| MCP tool params documented | Rules file with date range semantics |

## Test plan

- [x] All tests pass (39 core + 22 local + flutter analyze clean)
- [x] `settings.json` validates as valid JSON
- [x] Prettier hook tested and working
- [ ] Verify deny rules work in next session (sensitive file reads blocked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)