### PR TITLE
feat: MCP polish — HTTP-only, CLI updates, docs

### DIFF
--- a/.claude/rules/mcp-tools.md
+++ b/.claude/rules/mcp-tools.md
@@ -24,10 +24,11 @@
 - `date_to`: exclusive (`<`)
 - To get all of March: `date_from: "2026-03-01"`, `date_to: "2026-04-01"`
 
-## Transports
+## Transport
 
-- **HTTP**: `POST /mcp` on the Hono server (port 1940), session-based
-- **stdio**: `npx tsx src/mcp-stdio.ts`, for direct Claude integration
+MCP is served over Streamable HTTP at `POST /mcp` on the Hono server (port 1940). Session-based with `mcp-session-id` headers. Auth follows the server's middleware (localhost bypasses, remote needs API key).
+
+Setup: `claude mcp add parachute-daily --transport http --url http://localhost:1940/mcp`
 
 ## When Modifying Tools
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,11 +44,8 @@ See `.claude/rules/mcp-tools.md` for detailed params and date range semantics.
 ## Running
 
 ```bash
-# Server (port 1940)
+# Server (port 1940, includes MCP at /mcp)
 cd local && npx tsx watch src/server.ts
-
-# MCP stdio (for Claude)
-cd local && npx tsx src/mcp-stdio.ts
 
 # Flutter app
 cd app && flutter run -d macos       # desktop
@@ -69,10 +66,12 @@ Feature branches + PRs for all changes. Run all tests before committing. See `.c
 ```
 Flutter App  →  HTTP API (:1940)  →  SQLite (notes/tags/links)
                                           ↑
-Claude/AI    →  MCP stdio server  ────────┘
+Claude/AI    →  MCP (/mcp)  ──────────────┘
 ```
 
 Server at `~/.parachute/daily.db`. Assets at `~/.parachute/daily/assets/`. Auth via API keys in `~/.parachute/server.yaml` (localhost bypasses auth).
+
+MCP setup for Claude Code: `claude mcp add parachute-daily --transport http --url http://localhost:1940/mcp`
 
 ## App Views (Three Tabs)
 

--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -14,7 +14,7 @@ User → Flutter App → GraphApiService → Parachute Daily Server (port 1940)
    Local SQLite cache                    SQLite database
    (offline journal)                     (Notes, Tags, Links, Attachments)
                                                  ↓
-                                         MCP stdio server
+                                         MCP endpoint (/mcp)
                                          (Claude / AI agents)
 ```
 

--- a/local/package.json
+++ b/local/package.json
@@ -10,7 +10,6 @@
   "scripts": {
     "dev": "tsx watch src/server.ts",
     "start": "tsx src/server.ts",
-    "mcp": "tsx src/mcp-stdio.ts",
     "cli": "tsx src/cli.ts",
     "test": "node --experimental-vm-modules node_modules/.bin/vitest run",
     "test:watch": "node --experimental-vm-modules node_modules/.bin/vitest"

--- a/local/src/cli.ts
+++ b/local/src/cli.ts
@@ -19,10 +19,6 @@ switch (command) {
     await import("./server.js");
     break;
 
-  case "mcp":
-    await import("./mcp-stdio.js");
-    break;
-
   case "init":
     await runInit();
     break;
@@ -68,16 +64,17 @@ async function runInit() {
 
 async function runStatus() {
   const port = process.env.PORT ?? "1940";
-  const url = `http://localhost:${port}/api/health`;
+  const baseUrl = `http://localhost:${port}`;
 
   try {
-    const res = await fetch(url);
+    const res = await fetch(`${baseUrl}/api/health`);
     if (res.ok) {
       const data = await res.json() as Record<string, unknown>;
       console.log(`Server:        running on :${port}`);
       console.log(`Version:       ${data.version}`);
       console.log(`Auth mode:     ${data.auth_mode}`);
       console.log(`Transcription: ${data.transcription_available ? "available" : "not available"}`);
+      console.log(`MCP endpoint:  ${baseUrl}/mcp`);
     } else {
       console.log(`Server responded with ${res.status}`);
     }
@@ -92,9 +89,12 @@ Parachute — personal graph server
 
 Usage:
   parachute serve     Start the HTTP server (default :1940)
-  parachute mcp       Start the MCP stdio server (for Claude)
   parachute init      Initialize database and show status
   parachute status    Check if server is running
+
+The server includes an MCP endpoint at /mcp for AI agent access.
+Add it to Claude Code:
+  claude mcp add parachute-daily --transport http --url http://localhost:1940/mcp
 
 Environment:
   PORT                 Server port (default: 1940)


### PR DESCRIPTION
## Summary

- Standardize on HTTP transport for MCP (remove stdio from CLI and recommended path)
- Add MCP endpoint info to `parachute status` output
- Update CLI help with Claude Code setup instructions
- Update all architecture diagrams and docs to reflect `/mcp` endpoint

## Changes

- `local/src/cli.ts`: Remove `mcp` command, add MCP URL to status output, add setup instructions to help
- `local/package.json`: Remove `mcp` npm script
- `CLAUDE.md`, `app/CLAUDE.md`: Update architecture diagrams (stdio → HTTP)
- `.claude/rules/mcp-tools.md`: HTTP-only transport docs

## Rationale

The server is already running for the Flutter app — MCP is just another route on it. HTTP transport works over the network, uses the existing auth system, and doesn't require clients to spawn child processes. stdio file is kept in the repo but not recommended.

## Test plan

- [x] 39 core tests pass
- [x] 22 local tests pass
- [x] flutter analyze clean (0 errors)
- [x] MCP tools list verified via curl (all 11 tools with tag descriptions)
- [x] `parachute status` shows MCP endpoint

Addresses #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)