### PR TITLE
feat: vault picker + collapse transcription into server settings

### DIFF
--- a/lib/core/providers/app_state_provider.dart
+++ b/lib/core/providers/app_state_provider.dart
@@ -158,6 +158,36 @@ final serverUrlProvider = AsyncNotifierProvider<ServerUrlNotifier, String?>(() {
   return ServerUrlNotifier();
 });
 
+/// Notifier for selected vault name with persistence.
+///
+/// When set, API calls route to `/vaults/{name}/api/*` instead of `/api/*`.
+/// Empty or null means use the default vault.
+class VaultNameNotifier extends AsyncNotifier<String?> {
+  static const _key = 'parachute_vault_name';
+
+  @override
+  Future<String?> build() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(_key);
+  }
+
+  Future<void> setVaultName(String? name) async {
+    final prefs = await SharedPreferences.getInstance();
+    if (name != null && name.isNotEmpty) {
+      await prefs.setString(_key, name);
+      state = AsyncData(name);
+    } else {
+      await prefs.remove(_key);
+      state = const AsyncData(null);
+    }
+  }
+}
+
+/// Selected vault name provider (null = default vault)
+final vaultNameProvider = AsyncNotifierProvider<VaultNameNotifier, String?>(() {
+  return VaultNameNotifier();
+});
+
 /// App mode based on flavor and server configuration
 ///
 /// - Daily flavor: Always dailyOnly (Chat/Vault not available)

--- a/lib/core/providers/backend_health_provider.dart
+++ b/lib/core/providers/backend_health_provider.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../services/backend_health_service.dart';
 import '../services/transcription_api_service.dart';
+import 'app_state_provider.dart' show apiKeyProvider;
 import 'feature_flags_provider.dart';
 import '../../features/daily/recorder/providers/service_providers.dart'
     show transcriptionServiceUrlProvider, transcriptionServiceApiKeyProvider;
@@ -47,9 +48,9 @@ final periodicServerHealthProvider = StreamProvider<ServerHealthStatus?>((ref) a
   }
 });
 
-/// Whether an external transcription service is configured and reachable.
+/// Whether transcription is available (custom endpoint or vault with scribe).
 ///
-/// Checks the transcription service URL and periodically verifies reachability.
+/// Periodically checks reachability of whichever transcription endpoint is active.
 /// Used by the recording flow to decide server vs local transcription path.
 final serverTranscriptionAvailableProvider = Provider<bool>((ref) {
   final reachable = ref.watch(transcriptionServiceReachableProvider);
@@ -58,12 +59,6 @@ final serverTranscriptionAvailableProvider = Provider<bool>((ref) {
 
 /// Periodic reachability check for the transcription service.
 final transcriptionServiceReachableProvider = StreamProvider<bool>((ref) async* {
-  final url = ref.watch(transcriptionServiceUrlProvider).valueOrNull;
-  if (url == null || url.isEmpty) {
-    yield false;
-    return;
-  }
-
   final service = ref.watch(transcriptionApiServiceProvider);
   if (service == null) {
     yield false;
@@ -82,12 +77,25 @@ final transcriptionServiceReachableProvider = StreamProvider<bool>((ref) async* 
 });
 
 /// Provider for a TranscriptionApiService instance built from current settings.
+///
+/// Uses the custom transcription URL if configured, otherwise falls back to
+/// the vault server URL (vault can host transcription via scribe).
 final transcriptionApiServiceProvider = Provider<TranscriptionApiService?>((ref) {
-  final url = ref.watch(transcriptionServiceUrlProvider).valueOrNull;
-  if (url == null || url.isEmpty) return null;
+  // Try custom transcription URL first
+  final customUrl = ref.watch(transcriptionServiceUrlProvider).valueOrNull;
+  if (customUrl != null && customUrl.isNotEmpty) {
+    final apiKey = ref.watch(transcriptionServiceApiKeyProvider).valueOrNull;
+    final service = TranscriptionApiService(baseUrl: customUrl, apiKey: apiKey);
+    ref.onDispose(() => service.dispose());
+    return service;
+  }
 
-  final apiKey = ref.watch(transcriptionServiceApiKeyProvider).valueOrNull;
-  final service = TranscriptionApiService(baseUrl: url, apiKey: apiKey);
+  // Fall back to vault URL (vault can serve /v1/audio/transcriptions via scribe)
+  final vaultUrl = ref.watch(aiServerUrlProvider).valueOrNull;
+  if (vaultUrl == null || vaultUrl.isEmpty) return null;
+
+  final vaultApiKey = ref.watch(apiKeyProvider).valueOrNull;
+  final service = TranscriptionApiService(baseUrl: vaultUrl, apiKey: vaultApiKey);
   ref.onDispose(() => service.dispose());
   return service;
 });

--- a/lib/core/services/graph_api_service.dart
+++ b/lib/core/services/graph_api_service.dart
@@ -4,9 +4,12 @@ import 'package:http/http.dart' as http;
 import '../models/thing.dart';
 
 /// Service for communicating with the Parachute Daily v3 API.
-/// Targets /api/* on the local server.
+///
+/// Routes to `/api/*` by default, or `/vaults/{name}/api/*` when a
+/// vault name is specified (multi-vault support).
 class GraphApiService {
   final String baseUrl;
+  final String? vaultName;
   final http.Client _client;
   final String? _apiKey;
   final Duration _timeout;
@@ -16,6 +19,7 @@ class GraphApiService {
 
   GraphApiService({
     required this.baseUrl,
+    this.vaultName,
     String? apiKey,
     http.Client? client,
     Duration timeout = const Duration(seconds: 15),
@@ -23,6 +27,14 @@ class GraphApiService {
   })  : _apiKey = apiKey,
         _client = client ?? http.Client(),
         _timeout = timeout;
+
+  /// API path prefix — `/api` for default vault, `/vaults/{name}/api` for named vault.
+  String get _apiPrefix {
+    if (vaultName != null && vaultName!.isNotEmpty) {
+      return '/vaults/$vaultName/api';
+    }
+    return '/api';
+  }
 
   // ---- Notes ----
 
@@ -188,7 +200,7 @@ class GraphApiService {
   /// Upload an audio file, returns the relative storage path.
   Future<String?> uploadAudio(Uint8List data, String filename) async {
     try {
-      final uri = Uri.parse('$baseUrl/api/storage/upload');
+      final uri = Uri.parse('$baseUrl$_apiPrefix/storage/upload');
       final request = http.MultipartRequest('POST', uri);
       _addAuthHeaders(request.headers);
       request.files.add(http.MultipartFile.fromBytes(
@@ -217,7 +229,7 @@ class GraphApiService {
   /// Check server health.
   Future<bool> isHealthy() async {
     try {
-      final uri = Uri.parse('$baseUrl/api/health');
+      final uri = Uri.parse('$baseUrl$_apiPrefix/health');
       final response = await _client.get(uri, headers: _headers()).timeout(
         const Duration(seconds: 5),
       );
@@ -230,11 +242,37 @@ class GraphApiService {
     }
   }
 
+  // ---- Vaults ----
+
+  /// Fetch the list of available vaults from the server.
+  /// Returns vault names, or null on error.
+  Future<List<String>?> fetchVaults() async {
+    try {
+      final uri = Uri.parse('$baseUrl/vaults');
+      final response = await _client.get(uri, headers: _headers()).timeout(
+        const Duration(seconds: 5),
+      );
+      if (response.statusCode == 200) {
+        final data = jsonDecode(response.body);
+        if (data is List) {
+          return data
+              .map((v) => (v is Map ? v['name'] as String? : v?.toString()) ?? '')
+              .where((n) => n.isNotEmpty)
+              .toList();
+        }
+      }
+      return null;
+    } catch (e) {
+      debugPrint('[GraphApiService] fetchVaults error: $e');
+      return null;
+    }
+  }
+
   // ---- HTTP Helpers ----
 
   Future<dynamic> _get(String path, Map<String, String> params) async {
     try {
-      final uri = Uri.parse('$baseUrl/api$path').replace(queryParameters: params.isNotEmpty ? params : null);
+      final uri = Uri.parse('$baseUrl$_apiPrefix$path').replace(queryParameters: params.isNotEmpty ? params : null);
       final response = await _client.get(uri, headers: _headers()).timeout(_timeout);
       _notifyReachable(true);
       if (response.statusCode == 200) return jsonDecode(response.body);
@@ -250,7 +288,7 @@ class GraphApiService {
 
   Future<dynamic> _post(String path, Map<String, dynamic> body) async {
     try {
-      final uri = Uri.parse('$baseUrl/api$path');
+      final uri = Uri.parse('$baseUrl$_apiPrefix$path');
       final response = await _client.post(
         uri,
         headers: _headers(),
@@ -271,7 +309,7 @@ class GraphApiService {
 
   Future<dynamic> _patch(String path, Map<String, dynamic> body) async {
     try {
-      final uri = Uri.parse('$baseUrl/api$path');
+      final uri = Uri.parse('$baseUrl$_apiPrefix$path');
       final response = await _client.patch(
         uri,
         headers: _headers(),
@@ -290,7 +328,7 @@ class GraphApiService {
 
   Future<dynamic> _delete(String path) async {
     try {
-      final uri = Uri.parse('$baseUrl/api$path');
+      final uri = Uri.parse('$baseUrl$_apiPrefix$path');
       final response = await _client.delete(uri, headers: _headers()).timeout(_timeout);
       _notifyReachable(true);
       if (response.statusCode == 200) return jsonDecode(response.body);
@@ -305,7 +343,7 @@ class GraphApiService {
 
   Future<dynamic> _deleteWithBody(String path, Map<String, dynamic> body) async {
     try {
-      final uri = Uri.parse('$baseUrl/api$path');
+      final uri = Uri.parse('$baseUrl$_apiPrefix$path');
       final request = http.Request('DELETE', uri);
       request.headers.addAll(_headers());
       request.body = jsonEncode(body);

--- a/lib/features/daily/journal/providers/journal_providers.dart
+++ b/lib/features/daily/journal/providers/journal_providers.dart
@@ -6,7 +6,7 @@ import 'package:parachute/core/models/thing.dart';
 import 'package:parachute/core/providers/feature_flags_provider.dart'
     show aiServerUrlProvider;
 import 'package:parachute/core/providers/app_state_provider.dart'
-    show apiKeyProvider;
+    show apiKeyProvider, vaultNameProvider;
 import 'package:parachute/core/providers/backend_health_provider.dart'
     show periodicServerHealthProvider;
 import 'package:parachute/core/providers/connectivity_provider.dart'
@@ -47,9 +47,11 @@ final graphApiServiceProvider = Provider<GraphApiService>((ref) {
   final baseUrl = urlAsync.valueOrNull ?? AppConfig.defaultServerUrl;
   final apiKeyAsync = ref.watch(apiKeyProvider);
   final apiKey = apiKeyAsync.valueOrNull;
+  final vaultName = ref.watch(vaultNameProvider).valueOrNull;
 
   return GraphApiService(
     baseUrl: baseUrl,
+    vaultName: vaultName,
     apiKey: apiKey,
     onReachabilityChanged: (reachable) {
       ref.read(serverReachableOverrideProvider.notifier).state = reachable;

--- a/lib/features/settings/screens/settings_screen.dart
+++ b/lib/features/settings/screens/settings_screen.dart
@@ -4,7 +4,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:parachute/core/theme/design_tokens.dart';
 import '../widgets/omi_device_section.dart';
 import '../widgets/server_settings_section.dart';
-import '../widgets/transcription_service_section.dart';
 import '../widgets/transcription_settings_section.dart';
 import '../widgets/about_section.dart';
 import '../widgets/settings_card.dart';
@@ -43,13 +42,6 @@ class SettingsScreen extends ConsumerWidget {
           SettingsCard(
             isDark: isDark,
             child: const ServerSettingsSection(),
-          ),
-          SizedBox(height: Spacing.xl),
-
-          // Transcription Service
-          SettingsCard(
-            isDark: isDark,
-            child: const TranscriptionServiceSection(),
           ),
           SizedBox(height: Spacing.xl),
 

--- a/lib/features/settings/widgets/server_settings_section.dart
+++ b/lib/features/settings/widgets/server_settings_section.dart
@@ -3,11 +3,14 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:parachute/core/config/app_config.dart';
 import 'package:parachute/core/theme/design_tokens.dart';
 import 'package:parachute/core/providers/app_state_provider.dart'
-    show serverUrlProvider, apiKeyProvider;
+    show serverUrlProvider, apiKeyProvider, vaultNameProvider;
 import 'package:parachute/core/providers/feature_flags_provider.dart';
 import 'package:parachute/core/services/backend_health_service.dart';
+import 'package:parachute/core/services/graph_api_service.dart';
+import 'package:parachute/core/services/transcription_api_service.dart';
+import 'package:parachute/features/daily/recorder/providers/service_providers.dart';
 
-/// Server connection settings section
+/// Server connection settings section with vault picker and transcription config.
 class ServerSettingsSection extends ConsumerStatefulWidget {
   const ServerSettingsSection({super.key});
 
@@ -18,33 +21,82 @@ class ServerSettingsSection extends ConsumerStatefulWidget {
 class _ServerSettingsSectionState extends ConsumerState<ServerSettingsSection> {
   final _serverUrlController = TextEditingController();
   final _apiKeyController = TextEditingController();
+  final _transcriptionUrlController = TextEditingController();
+  final _transcriptionApiKeyController = TextEditingController();
+
+  List<String>? _availableVaults;
+  String? _selectedVault;
+  bool _loadingVaults = false;
+  bool _useCustomTranscription = false;
 
   @override
   void initState() {
     super.initState();
-    _loadServerUrl();
-    _loadApiKey();
+    _loadSettings();
   }
 
   @override
   void dispose() {
     _serverUrlController.dispose();
     _apiKeyController.dispose();
+    _transcriptionUrlController.dispose();
+    _transcriptionApiKeyController.dispose();
     super.dispose();
   }
 
-  Future<void> _loadServerUrl() async {
+  Future<void> _loadSettings() async {
     final featureFlags = ref.read(featureFlagsServiceProvider);
     final serverUrl = await featureFlags.getAiServerUrl();
+    final apiKey = ref.read(apiKeyProvider).valueOrNull;
+    final vaultName = ref.read(vaultNameProvider).valueOrNull;
+    final transcriptionUrl =
+        await ref.read(transcriptionServiceUrlProvider.future);
+    final transcriptionApiKey =
+        await ref.read(transcriptionServiceApiKeyProvider.future);
+
     if (mounted) {
-      _serverUrlController.text = serverUrl;
+      setState(() {
+        _serverUrlController.text = serverUrl;
+        if (apiKey != null) _apiKeyController.text = apiKey;
+        _selectedVault = vaultName;
+        _useCustomTranscription =
+            transcriptionUrl != null && transcriptionUrl.isNotEmpty;
+        if (transcriptionUrl != null) {
+          _transcriptionUrlController.text = transcriptionUrl;
+        }
+        if (transcriptionApiKey != null) {
+          _transcriptionApiKeyController.text = transcriptionApiKey;
+        }
+      });
+
+      // Fetch vaults if we have a URL
+      if (serverUrl.isNotEmpty) {
+        _fetchVaults(serverUrl);
+      }
     }
   }
 
-  Future<void> _loadApiKey() async {
-    final apiKey = ref.read(apiKeyProvider).valueOrNull;
-    if (mounted && apiKey != null) {
-      _apiKeyController.text = apiKey;
+  Future<void> _fetchVaults(String url) async {
+    if (url.isEmpty) return;
+    setState(() => _loadingVaults = true);
+
+    final api = GraphApiService(
+      baseUrl: url,
+      apiKey: _apiKeyController.text.trim().isEmpty
+          ? null
+          : _apiKeyController.text.trim(),
+    );
+
+    try {
+      final vaults = await api.fetchVaults();
+      if (mounted) {
+        setState(() {
+          _availableVaults = vaults;
+          _loadingVaults = false;
+        });
+      }
+    } catch (_) {
+      if (mounted) setState(() => _loadingVaults = false);
     }
   }
 
@@ -53,15 +105,12 @@ class _ServerSettingsSectionState extends ConsumerState<ServerSettingsSection> {
     final featureFlags = ref.read(featureFlagsServiceProvider);
 
     try {
-      // Save using FeatureFlagsService (same key as working chat app)
-      await featureFlags.setAiServerUrl(url.isEmpty ? AppConfig.defaultServerUrl : url);
+      await featureFlags.setAiServerUrl(
+          url.isEmpty ? AppConfig.defaultServerUrl : url);
       featureFlags.clearCache();
-
-      // Invalidate the provider so ChatService rebuilds with the new URL
       ref.invalidate(aiServerUrlProvider);
-
-      // Also update serverUrlProvider for app mode detection (validates URL)
-      await ref.read(serverUrlProvider.notifier).setServerUrl(url.isEmpty ? null : url);
+      await ref.read(serverUrlProvider.notifier).setServerUrl(
+          url.isEmpty ? null : url);
 
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
@@ -73,6 +122,9 @@ class _ServerSettingsSectionState extends ConsumerState<ServerSettingsSection> {
           ),
         );
       }
+
+      // Refresh vault list with new URL
+      if (url.isNotEmpty) _fetchVaults(url);
     } catch (e) {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
@@ -98,6 +150,39 @@ class _ServerSettingsSectionState extends ConsumerState<ServerSettingsSection> {
     }
   }
 
+  Future<void> _saveVaultName(String? name) async {
+    setState(() => _selectedVault = name);
+    await ref
+        .read(vaultNameProvider.notifier)
+        .setVaultName(name == null || name.isEmpty ? null : name);
+  }
+
+  Future<void> _saveTranscriptionUrl() async {
+    final url = _transcriptionUrlController.text.trim();
+    await setTranscriptionServiceUrl(url.isEmpty ? null : url);
+    ref.invalidate(transcriptionServiceUrlProvider);
+  }
+
+  Future<void> _saveTranscriptionApiKey() async {
+    final key = _transcriptionApiKeyController.text.trim();
+    await ref
+        .read(transcriptionServiceApiKeyProvider.notifier)
+        .setApiKey(key.isEmpty ? null : key);
+  }
+
+  Future<void> _saveAll() async {
+    await _saveServerUrl();
+    await _saveApiKey(showSnackbar: false);
+    if (_useCustomTranscription) {
+      await _saveTranscriptionUrl();
+      await _saveTranscriptionApiKey();
+    } else {
+      // Clear custom transcription when using vault
+      await setTranscriptionServiceUrl(null);
+      ref.invalidate(transcriptionServiceUrlProvider);
+    }
+  }
+
   Future<void> _testServerConnection() async {
     final url = _serverUrlController.text.trim();
     if (url.isEmpty) {
@@ -110,7 +195,6 @@ class _ServerSettingsSectionState extends ConsumerState<ServerSettingsSection> {
       return;
     }
 
-    // Show loading
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
         content: Row(
@@ -120,7 +204,8 @@ class _ServerSettingsSectionState extends ConsumerState<ServerSettingsSection> {
               height: 16,
               child: CircularProgressIndicator(
                 strokeWidth: 2,
-                valueColor: AlwaysStoppedAnimation<Color>(BrandColors.softWhite),
+                valueColor:
+                    AlwaysStoppedAnimation<Color>(BrandColors.softWhite),
               ),
             ),
             SizedBox(width: Spacing.md),
@@ -131,19 +216,37 @@ class _ServerSettingsSectionState extends ConsumerState<ServerSettingsSection> {
       ),
     );
 
-    // Actually test the connection
     final healthService = BackendHealthService(baseUrl: url);
     try {
       final status = await healthService.checkHealth();
 
+      // Also test transcription endpoint
+      final transcriptionUrl = _useCustomTranscription
+          ? _transcriptionUrlController.text.trim()
+          : url;
+      final transcriptionKey = _useCustomTranscription
+          ? _transcriptionApiKeyController.text.trim()
+          : _apiKeyController.text.trim();
+      final transcriptionService = TranscriptionApiService(
+        baseUrl: transcriptionUrl,
+        apiKey: transcriptionKey.isEmpty ? null : transcriptionKey,
+      );
+      final transcriptionResult = await transcriptionService.checkConnection();
+      transcriptionService.dispose();
+
       if (mounted) {
         ScaffoldMessenger.of(context).clearSnackBars();
         if (status.isHealthy) {
+          final transcriptionMsg = transcriptionResult.authOk
+              ? ' · Transcription ready'
+              : transcriptionResult.reachable
+                  ? ' · Transcription auth failed'
+                  : '';
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(
               content: Text(status.serverVersion != null
-                  ? 'Connected to Parachute Computer v${status.serverVersion}'
-                  : 'Connected to Parachute Computer'),
+                  ? 'Connected to Parachute Computer v${status.serverVersion}$transcriptionMsg'
+                  : 'Connected to Parachute Computer$transcriptionMsg'),
               backgroundColor: BrandColors.success,
             ),
           );
@@ -178,6 +281,7 @@ class _ServerSettingsSectionState extends ConsumerState<ServerSettingsSection> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
+        // Section header
         Row(
           children: [
             Icon(
@@ -197,15 +301,18 @@ class _ServerSettingsSectionState extends ConsumerState<ServerSettingsSection> {
         ),
         SizedBox(height: Spacing.sm),
         Text(
-          'Connect to the Parachute Daily server for sync and search. '
+          'Connect to a Parachute Vault for sync, search, and transcription. '
           'Leave empty for offline mode.',
           style: TextStyle(
             fontSize: TypographyTokens.bodySmall,
-            color: isDark ? BrandColors.nightTextSecondary : BrandColors.driftwood,
+            color: isDark
+                ? BrandColors.nightTextSecondary
+                : BrandColors.driftwood,
           ),
         ),
         SizedBox(height: Spacing.lg),
 
+        // Server URL
         TextField(
           controller: _serverUrlController,
           decoration: InputDecoration(
@@ -226,11 +333,12 @@ class _ServerSettingsSectionState extends ConsumerState<ServerSettingsSection> {
         ),
         SizedBox(height: Spacing.md),
 
+        // API Key
         TextField(
           controller: _apiKeyController,
           decoration: InputDecoration(
             labelText: 'API Key',
-            hintText: 'para_...',
+            hintText: 'para_... or pvk_...',
             border: const OutlineInputBorder(),
             prefixIcon: const Icon(Icons.key),
             suffixIcon: IconButton(
@@ -244,8 +352,23 @@ class _ServerSettingsSectionState extends ConsumerState<ServerSettingsSection> {
           obscureText: true,
           onSubmitted: (_) => _saveApiKey(),
         ),
+        SizedBox(height: Spacing.md),
+
+        // Vault picker
+        _buildVaultPicker(isDark),
         SizedBox(height: Spacing.lg),
 
+        // Transcription toggle
+        _buildTranscriptionToggle(isDark),
+
+        // Custom transcription fields (collapsed by default)
+        if (_useCustomTranscription) ...[
+          SizedBox(height: Spacing.md),
+          _buildCustomTranscriptionFields(),
+        ],
+        SizedBox(height: Spacing.lg),
+
+        // Action buttons
         Row(
           children: [
             Expanded(
@@ -258,10 +381,7 @@ class _ServerSettingsSectionState extends ConsumerState<ServerSettingsSection> {
             SizedBox(width: Spacing.sm),
             Expanded(
               child: FilledButton.icon(
-                onPressed: () async {
-                  await _saveServerUrl();
-                  await _saveApiKey(showSnackbar: false);
-                },
+                onPressed: _saveAll,
                 icon: const Icon(Icons.save, size: 18),
                 label: const Text('Save'),
                 style: FilledButton.styleFrom(
@@ -270,6 +390,141 @@ class _ServerSettingsSectionState extends ConsumerState<ServerSettingsSection> {
               ),
             ),
           ],
+        ),
+      ],
+    );
+  }
+
+  Widget _buildVaultPicker(bool isDark) {
+    if (_loadingVaults) {
+      return Row(
+        children: [
+          const SizedBox(
+            width: 16,
+            height: 16,
+            child: CircularProgressIndicator(strokeWidth: 2),
+          ),
+          SizedBox(width: Spacing.sm),
+          Text(
+            'Loading vaults...',
+            style: TextStyle(
+              fontSize: TypographyTokens.bodySmall,
+              color: isDark
+                  ? BrandColors.nightTextSecondary
+                  : BrandColors.driftwood,
+            ),
+          ),
+        ],
+      );
+    }
+
+    if (_availableVaults == null || _availableVaults!.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return DropdownButtonFormField<String>(
+      value: _selectedVault,
+      decoration: const InputDecoration(
+        labelText: 'Vault',
+        border: OutlineInputBorder(),
+        prefixIcon: Icon(Icons.inventory_2_outlined),
+      ),
+      items: [
+        const DropdownMenuItem(
+          value: null,
+          child: Text('Default'),
+        ),
+        ..._availableVaults!.map((name) => DropdownMenuItem(
+              value: name,
+              child: Text(name),
+            )),
+      ],
+      onChanged: (name) => _saveVaultName(name),
+    );
+  }
+
+  Widget _buildTranscriptionToggle(bool isDark) {
+    return Row(
+      children: [
+        Icon(
+          Icons.record_voice_over,
+          size: 18,
+          color: isDark ? BrandColors.nightTextSecondary : BrandColors.driftwood,
+        ),
+        SizedBox(width: Spacing.sm),
+        Expanded(
+          child: Text(
+            _useCustomTranscription
+                ? 'Using custom transcription endpoint'
+                : 'Transcription via this server',
+            style: TextStyle(
+              fontSize: TypographyTokens.bodySmall,
+              color:
+                  isDark ? BrandColors.nightText : BrandColors.charcoal,
+            ),
+          ),
+        ),
+        TextButton(
+          onPressed: () {
+            setState(() {
+              _useCustomTranscription = !_useCustomTranscription;
+            });
+            if (!_useCustomTranscription) {
+              // Clear custom URL when switching back to vault
+              _transcriptionUrlController.clear();
+              _transcriptionApiKeyController.clear();
+              _saveTranscriptionUrl();
+              _saveTranscriptionApiKey();
+            }
+          },
+          child: Text(
+            _useCustomTranscription ? 'Use server' : 'Custom endpoint',
+            style: const TextStyle(fontSize: 12),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildCustomTranscriptionFields() {
+    return Column(
+      children: [
+        TextField(
+          controller: _transcriptionUrlController,
+          decoration: InputDecoration(
+            labelText: 'Transcription URL',
+            hintText: 'https://api.groq.com/openai',
+            border: const OutlineInputBorder(),
+            prefixIcon: const Icon(Icons.link),
+            suffixIcon: IconButton(
+              icon: const Icon(Icons.clear),
+              onPressed: () {
+                _transcriptionUrlController.clear();
+                _saveTranscriptionUrl();
+              },
+            ),
+          ),
+          keyboardType: TextInputType.url,
+          onSubmitted: (_) => _saveTranscriptionUrl(),
+        ),
+        SizedBox(height: Spacing.md),
+        TextField(
+          controller: _transcriptionApiKeyController,
+          decoration: InputDecoration(
+            labelText: 'Transcription API Key',
+            hintText: 'sk-...',
+            border: const OutlineInputBorder(),
+            prefixIcon: const Icon(Icons.key),
+            suffixIcon: IconButton(
+              icon: const Icon(Icons.clear),
+              onPressed: () {
+                _transcriptionApiKeyController.clear();
+                _saveTranscriptionApiKey();
+              },
+            ),
+          ),
+          obscureText: true,
+          onSubmitted: (_) => _saveTranscriptionApiKey(),
         ),
       ],
     );

--- a/lib/features/settings/widgets/transcription_settings_section.dart
+++ b/lib/features/settings/widgets/transcription_settings_section.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:parachute/core/theme/design_tokens.dart';
+import 'package:parachute/core/providers/backend_health_provider.dart'
+    show serverTranscriptionAvailableProvider;
 import 'package:parachute/features/daily/recorder/providers/service_providers.dart';
 
 /// Settings section for transcription mode (auto / server / local).
@@ -11,7 +13,7 @@ class TranscriptionSettingsSection extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final modeAsync = ref.watch(transcriptionModeProvider);
-    final serverAvailable = ref.watch(isTranscriptionServiceConfiguredProvider);
+    final serverAvailable = ref.watch(serverTranscriptionAvailableProvider);
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -80,7 +82,7 @@ class _StatusChip extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final color = serverAvailable ? BrandColors.success : BrandColors.driftwood;
-    final label = serverAvailable ? 'Service configured' : 'Local only';
+    final label = serverAvailable ? 'Server ready' : 'Local only';
 
     return Container(
       padding: EdgeInsets.symmetric(


### PR DESCRIPTION
## Summary
- Add vault picker dropdown to server settings — fetches available vaults from `GET /vaults`, routes API calls to `/vaults/{name}/api/*` when selected
- Collapse transcription config into the server settings card — defaults to vault URL, expandable "Custom endpoint" toggle for Groq/OpenAI
- `GraphApiService` now supports multi-vault routing via `_apiPrefix`
- `transcriptionApiServiceProvider` falls back to vault URL when no custom transcription URL is set
- Test Connection checks both vault health and transcription reachability

## Test plan
- [ ] Open Settings — verify single "Parachute Computer" card with URL, key, vault picker, transcription toggle
- [ ] Enter vault URL + save — verify vault dropdown populates
- [ ] Select a vault — verify API calls route correctly
- [ ] Default transcription — verify transcription works without custom endpoint
- [ ] Toggle "Custom endpoint" — verify URL/key fields appear, save works
- [ ] Test Connection — verify shows vault + transcription status
- [ ] `flutter analyze` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)