### PR TITLE
chore: migrate flutter_markdown, enforce PR workflow

### DIFF
--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -2,16 +2,29 @@
 
 ## Branching
 
-- Create a feature branch for every change: `feature/*`, `fix/*`, `docs/*`
+- **Never push directly to main.** All changes go through PRs.
+- Create a feature branch for every change: `feature/*`, `fix/*`, `docs/*`, `chore/*`
 - Open a PR with a summary even for self-merge — creates a paper trail
 - Squash-merge to keep main clean
+- Delete the branch after merge
+
+## PR Process
+
+1. Create a branch: `git checkout -b feature/my-change`
+2. Make changes, commit with conventional commits
+3. Push: `git push -u origin feature/my-change`
+4. Create PR: `gh pr create --title "feat: ..." --body "..."`
+5. Review the diff (or have it reviewed)
+6. Merge: `gh pr merge <number> --squash --delete-branch`
+
+**Do not** use `git push origin main` or merge without a PR. PRs are the record of what changed and why.
 
 ## Before Committing
 
-Run static analysis before committing:
+Run static analysis before every commit:
 
 ```bash
-cd app && flutter analyze
+flutter analyze
 ```
 
 If it fails, fix before committing. No exceptions.
@@ -34,4 +47,12 @@ Don't deploy mid-debug. The workflow is:
 
 ## PRs
 
-Use `gh pr create` with a summary. Include a test plan.
+Use `gh pr create` with a summary. Include a test plan. Format:
+
+```
+## Summary
+- Bullet points of what changed
+
+## Test plan
+- [ ] Checklist of things to verify
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,7 +163,7 @@ flutter test integration_test/daily_test.dart
 
 ## Workflow
 
-Feature branches + PRs for all changes. Run `flutter analyze` before committing. See `.claude/rules/workflow.md`.
+**Never push directly to main.** All changes go through feature branches and PRs. Run `flutter analyze` before committing. See `.claude/rules/workflow.md` for full process.
 
 ## Gotchas
 

--- a/lib/core/screens/note_detail_screen.dart
+++ b/lib/core/screens/note_detail_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/foundation.dart' show listEquals;
 import 'package:flutter/material.dart';
-import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:parachute/core/models/thing.dart';
 import 'package:parachute/core/widgets/tag_input.dart';

--- a/lib/features/daily/journal/screens/entry_detail_screen.dart
+++ b/lib/features/daily/journal/screens/entry_detail_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/foundation.dart' show listEquals;
 import 'package:flutter/material.dart';
-import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:parachute/core/theme/design_tokens.dart';
 import 'package:parachute/core/widgets/tag_input.dart';

--- a/lib/features/daily/journal/widgets/journal_entry_card.dart
+++ b/lib/features/daily/journal/widgets/journal_entry_card.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 import 'package:flutter/material.dart';
-import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:parachute/core/theme/design_tokens.dart';
 import 'package:parachute/core/providers/file_system_provider.dart';

--- a/lib/features/daily/journal/widgets/journal_entry_row.dart
+++ b/lib/features/daily/journal/widgets/journal_entry_row.dart
@@ -1,7 +1,7 @@
 import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:parachute/core/theme/design_tokens.dart';
 import 'package:parachute/core/providers/file_system_provider.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -515,14 +515,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.2.0"
-  flutter_markdown:
+  flutter_markdown_plus:
     dependency: "direct main"
     description:
-      name: flutter_markdown
-      sha256: "08fb8315236099ff8e90cb87bb2b935e0a724a3af1623000a9cec930468e0f27"
+      name: flutter_markdown_plus
+      sha256: "039177906850278e8fb1cd364115ee0a46281135932fa8ecea8455522166d2de"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7+1"
+    version: "1.0.7"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   dio: ^5.4.0
 
   # Markdown
-  flutter_markdown: ^0.7.0
+  flutter_markdown_plus: ^1.0.7
   markdown: ^7.2.2
 
   # Storage
@@ -30,7 +30,7 @@ dependencies:
   path: ^1.9.0
   shared_preferences: ^2.0.0
   sqlite3: ^2.4.0
-  sqlite3_flutter_libs: ^0.5.0
+  sqlite3_flutter_libs: '>=0.5.0 <0.7.0'
 
   # Deep Links
   app_links: ^6.3.2

--- a/test/content_builder_test.dart
+++ b/test/content_builder_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
 
 const _testMarkdown = '''
 ## Summary

--- a/test/safemardown_test.dart
+++ b/test/safemardown_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
 
 const _testMarkdown = '''
 ## Summary


### PR DESCRIPTION
## Summary
- Migrate from discontinued `flutter_markdown` to `flutter_markdown_plus` (^1.0.7) — drop-in replacement across 4 lib files and 2 test files (#30)
- Widen `sqlite3_flutter_libs` constraint to `>=0.5.0 <0.7.0` for future upgrade path from EOL 0.5.x (#31)
- Enforce PR workflow: update `.claude/rules/workflow.md` with explicit "never push to main" rule, detailed PR process, template format
- Update CLAUDE.md workflow section to reinforce PR requirement

## Test plan
- [ ] `flutter analyze` — no new warnings
- [ ] App builds and runs — markdown rendering works in journal entries, note detail, digest
- [ ] Tests pass: `flutter test test/content_builder_test.dart` and `flutter test test/safemardown_test.dart`

Closes #30, partially addresses #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)