### PR TITLE
feat: restructure tabs — Reader / Capture / Vault

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,13 +20,13 @@ User → Flutter App → GraphApiService → Parachute Vault server
 
 ### Navigation
 
-Three-tab layout: **Digest**, **Daily**, **Docs**.
+Three-tab layout: **Reader**, **Capture**, **Vault**.
 
 | Tab | Query | Description |
 |-----|-------|-------------|
-| **Digest** | `#digest AND NOT #archived` | AI briefs, clipped content |
-| **Daily** | `#daily`, grouped by date | Voice memos, typed notes |
-| **Docs** | `#doc*`, searchable | Blog drafts, meeting notes, lists |
+| **Reader** | `#reader NOT #archived` | Content to process — AI briefs, articles, digests |
+| **Capture** | `#spoken OR #typed OR #clipped`, grouped by date | Voice memos, typed thoughts, clipped quotes |
+| **Vault** | Search + tag browser + saved views | Browse all notes, filter by tag, saved views |
 
 ## Directory Structure
 
@@ -51,21 +51,21 @@ lib/
 │   │   ├── design_tokens.dart       # BrandColors (use BrandColors.forest, NOT DesignTokens)
 │   │   └── app_theme.dart
 │   ├── screens/
-│   │   └── note_detail_screen.dart  # Shared note viewer/editor (Digest + Docs)
+│   │   └── note_detail_screen.dart  # Shared note viewer/editor
 │   └── widgets/                     # Shared UI components
 └── features/
-    ├── daily/                       # Voice journaling (offline-capable)
-    │   ├── home/                    # HomeScreen — main journal view
-    │   ├── journal/                 # Journal CRUD, entry display, local cache
+    ├── daily/                       # Capture tab — voice, typed, clipped (offline-capable)
+    │   ├── home/                    # HomeScreen — main capture view
+    │   ├── journal/                 # Capture CRUD, entry display, local cache
     │   ├── recorder/                # Audio recording & transcription
     │   ├── capture/                 # Photo/handwriting input
-    │   └── search/                  # Journal search
-    ├── digest/                      # AI-surfaced content inbox
-    │   ├── screens/                 # DigestScreen — cards, archive toggle, pinning
-    │   └── providers/               # Digest data + grouping providers
-    ├── docs/                        # Persistent documents
-    │   ├── screens/                 # DocsScreen — grouped by sub-tag, searchable
-    │   └── providers/               # Docs data + search providers
+    │   └── search/                  # Capture search
+    ├── digest/                      # Reader tab — content to process
+    │   ├── screens/                 # DigestScreen (Reader) — cards, archive, pinning
+    │   └── providers/               # Reader data + grouping providers
+    ├── vault/                       # Vault tab — search, browse, saved views
+    │   ├── screens/                 # VaultScreen — search + tag browser
+    │   └── providers/               # Vault search + browse providers
     ├── settings/                    # App settings (server URL, vault, transcription, Omi)
     └── onboarding/                  # Setup flow
 ```
@@ -81,16 +81,23 @@ Everything is a **Note**, differentiated by flat **Tags**:
 
 ### Built-in Tags
 
+**Content type (what it is):**
 ```
-#daily      — user-captured content (voice memos, typed notes)
-#doc        — persistent documents (blog drafts, grocery lists)
-#digest     — AI/system-created content for the user
-#pinned     — kept prominent (applies to any note)
-#archived   — user is done with this (applies to any note)
-#voice      — note was transcribed from voice
+#spoken     — transcribed from voice
+#typed      — written by hand
+#clipped    — grabbed from elsewhere (quote, link, photo)
+#doc        — long-form document (blog draft, meeting notes, list)
+#reader     — content to process (AI briefs, articles, digests)
+#view       — saved view definition (query + display config)
 ```
 
-Tags use optional `/` hierarchy: `#doc/meeting`, `#doc/draft`. The Docs tab queries `LIKE 'doc%'` so sub-tags surface automatically. A note can have multiple tags (e.g., `#daily` + `#doc/meeting` appears in both tabs).
+**State (applies to any note):**
+```
+#pinned     — kept prominent
+#archived   — user is done with this
+```
+
+Tags are flat and composable. A note can have multiple tags. The Capture tab shows `#spoken`, `#typed`, `#clipped` grouped by date. The Reader tab shows `#reader`. The Vault tab shows everything via search and tag filtering. Tags use optional `/` hierarchy for sub-categories: `#doc/meeting`, `#reader/summary`.
 
 ### Server API
 

--- a/lib/core/models/thing.dart
+++ b/lib/core/models/thing.dart
@@ -25,12 +25,17 @@ class Note {
 
   // ---- Type checks ----
 
-  bool get isDaily => hasTag('daily');
+  bool get isSpoken => hasTag('spoken');
+  bool get isTyped => hasTag('typed');
+  bool get isClipped => hasTag('clipped');
   bool get isDoc => hasTag('doc');
-  bool get isDigest => hasTag('digest');
-  bool get isVoice => hasTag('voice');
+  bool get isReader => hasTag('reader');
+  bool get isView => hasTag('view');
   bool get isPinned => hasTag('pinned');
   bool get isArchived => hasTag('archived');
+
+  /// Whether this is a capture-type note (spoken, typed, or clipped).
+  bool get isCapture => isSpoken || isTyped || isClipped;
 
   // ---- Serialization ----
 

--- a/lib/features/daily/journal/providers/journal_providers.dart
+++ b/lib/features/daily/journal/providers/journal_providers.dart
@@ -143,7 +143,7 @@ class _SelectedJournalNotifier extends AutoDisposeAsyncNotifier<JournalDay> {
 /// This is the boundary between the v3 data model (Note + tags) and the
 /// Daily tab's specialized view model (JournalEntry with type, audio, etc.).
 JournalEntry _noteToEntry(Note note, {String? audioPath, bool isPending = false}) {
-  final isVoice = note.hasTag('voice');
+  final isVoice = note.hasTag('spoken');
   return JournalEntry(
     id: note.id,
     title: note.path ?? '',
@@ -202,7 +202,7 @@ Future<JournalDay> _loadJournal(
         dateStr, nextDateStr, serverNotes.map((n) => n.id).toSet(),
       );
       // Fetch and cache audio paths for voice notes (parallel).
-      final voiceNotes = serverNotes.where((n) => n.isVoice).toList();
+      final voiceNotes = serverNotes.where((n) => n.isSpoken).toList();
       if (voiceNotes.isNotEmpty) {
         final audioPaths = await Future.wait(
           voiceNotes.map((n) => api.getAudioPath(n.id)),
@@ -240,7 +240,7 @@ Future<void> _flushPendingOps(
     final pendingCreates = cache.getPendingCreates();
     for (final note in pendingCreates) {
       final audioPath = cache.getAudioPath(note.id);
-      final isVoice = note.hasTag('voice');
+      final isVoice = note.hasTag('spoken');
 
       // Voice notes with local audio: use ingest endpoint (atomic)
       if (isVoice && audioPath != null && audioPath.startsWith('/')) {
@@ -269,7 +269,7 @@ Future<void> _flushPendingOps(
       }
 
       // Non-voice notes or notes with server audio paths: create directly
-      final tags = note.tags.isNotEmpty ? note.tags : ['daily'];
+      final tags = note.tags.isNotEmpty ? note.tags : ['typed'];
       final serverNote = await api.createNote(
         content: note.content,
         tags: tags,

--- a/lib/features/daily/journal/screens/journal_screen.dart
+++ b/lib/features/daily/journal/screens/journal_screen.dart
@@ -356,15 +356,14 @@ class _JournalScreenState extends ConsumerState<JournalScreen> with WidgetsBindi
         id: entry.id,
         content: entry.content,
         createdAt: entry.createdAt,
-        tags: entry.tags ?? ['daily'],
+        tags: entry.tags ?? ['typed'],
       );
       cache.putNotes([note]);
     } else {
       // Offline — save to cache as pending_create
       final cache = await ref.read(noteLocalCacheProvider.future);
       final localId = 'pending-${DateTime.now().millisecondsSinceEpoch}';
-      final tags = <String>['daily'];
-      if (type == JournalEntryType.voice) tags.add('voice');
+      final tags = <String>[type == JournalEntryType.voice ? 'spoken' : 'typed'];
       final pendingNote = Note(id: localId, content: content, createdAt: DateTime.now(), tags: tags);
       cache.insertPendingCreate(pendingNote, audioPath: audioPath);
       final pending = JournalEntry(
@@ -386,7 +385,7 @@ class _JournalScreenState extends ConsumerState<JournalScreen> with WidgetsBindi
 
   static String _entryTypeString(JournalEntryType type) {
     switch (type) {
-      case JournalEntryType.voice: return 'voice';
+      case JournalEntryType.voice: return 'spoken';
       case JournalEntryType.photo: return 'photo';
       case JournalEntryType.handwriting: return 'handwriting';
       case JournalEntryType.linked: return 'linked';
@@ -418,8 +417,7 @@ class _JournalScreenState extends ConsumerState<JournalScreen> with WidgetsBindi
     // Step 1: Save to cache as pending_create — content is now safe
     final cache = await ref.read(noteLocalCacheProvider.future);
     final localId = 'pending-${DateTime.now().millisecondsSinceEpoch}';
-    final tags = <String>['daily'];
-    if (type == JournalEntryType.voice) tags.add('voice');
+    final tags = <String>[type == JournalEntryType.voice ? 'spoken' : 'typed'];
     final pendingNote = Note(id: localId, content: content, createdAt: DateTime.now(), tags: tags);
     cache.insertPendingCreate(pendingNote, audioPath: audioPath);
     final pending = JournalEntry(
@@ -464,7 +462,7 @@ class _JournalScreenState extends ConsumerState<JournalScreen> with WidgetsBindi
       if (!mounted) return;
       final serverNote = Note(
         id: entry.id, content: entry.content,
-        createdAt: entry.createdAt, tags: entry.tags ?? ['daily'],
+        createdAt: entry.createdAt, tags: entry.tags ?? ['typed'],
       );
       cache.putNotes([serverNote]);
 

--- a/lib/features/daily/journal/services/daily_api_service.dart
+++ b/lib/features/daily/journal/services/daily_api_service.dart
@@ -41,8 +41,9 @@ class ApiSearchResult {
 /// All endpoints are under /api/ on the server at [baseUrl].
 ///
 /// Key mappings:
-///   Journal entries = Notes tagged "daily"
-///   Voice entries   = Notes tagged "daily" + "voice"
+///   Spoken entries  = Notes tagged "spoken"
+///   Typed entries   = Notes tagged "typed"
+///   Clipped entries = Notes tagged "clipped"
 ///   Audio files     = Attachments on notes
 class DailyApiService {
   final String baseUrl;
@@ -76,15 +77,19 @@ class DailyApiService {
   // Journal Entry CRUD — backed by Notes tagged "daily"
   // ===========================================================================
 
+  /// Tags that represent capture-type notes (shown in the Capture tab).
+  static const captureTags = ['spoken', 'typed', 'clipped'];
+
   /// Fetch notes for a specific date (YYYY-MM-DD).
   ///
+  /// Queries for capture-type tags (spoken, typed, clipped) by default.
   /// Returns `null` on network error — callers should fall back to cache.
   /// Returns `[]` when the server responds with no notes — authoritative empty.
-  Future<List<Note>?> getNotes({required String date}) async {
+  Future<List<Note>?> getNotes({required String date, String? tag}) async {
     final nextDate = _nextDate(date);
     final uri = Uri.parse('$baseUrl$_apiPrefix/notes').replace(
       queryParameters: {
-        'tag': 'daily',
+        'tag': tag ?? 'spoken,typed,clipped',
         'date_from': '${date}T00:00:00.000Z',
         'date_to': '${nextDate}T00:00:00.000Z',
         'limit': '100',
@@ -119,7 +124,7 @@ class DailyApiService {
   /// flushing offline-created entries). If omitted, the server sets it.
   Future<Note?> createNote({
     required String content,
-    List<String> tags = const ['daily'],
+    List<String> tags = const ['typed'],
     DateTime? createdAt,
   }) async {
     final uri = Uri.parse('$baseUrl$_apiPrefix/notes');
@@ -232,7 +237,7 @@ class DailyApiService {
 
       // Fields
       request.fields['created_at'] = createdAt.toIso8601String();
-      request.fields['tags'] = 'daily,voice';
+      request.fields['tags'] = 'spoken';
       request.fields['transcribe'] = transcribe.toString();
       request.fields['metadata'] = jsonEncode({
         'source': 'voice-memo',
@@ -316,7 +321,7 @@ class DailyApiService {
     // Create a note tagged daily + voice
     final note = await createNote(
       content: '',
-      tags: ['daily', 'voice'],
+      tags: ['spoken'],
     );
 
     // Attach the audio file to the note
@@ -352,7 +357,7 @@ class DailyApiService {
   }) async {
     if (query.trim().isEmpty) return [];
     final uri = Uri.parse('$baseUrl$_apiPrefix/search').replace(
-      queryParameters: {'q': query, 'tag': 'daily', 'limit': '$limit'},
+      queryParameters: {'q': query, 'tag': 'spoken,typed,clipped', 'limit': '$limit'},
     );
     debugPrint('[DailyApiService] GET $uri');
     try {
@@ -389,7 +394,7 @@ class DailyApiService {
     final entries = <JournalEntry>[];
     for (final note in notes) {
       String? audioPath;
-      if (note.isVoice) {
+      if (note.isSpoken) {
         audioPath = await getAudioPath(note.id);
       }
       entries.add(_noteToEntry(note, audioPath: audioPath));
@@ -404,8 +409,7 @@ class DailyApiService {
     DateTime? createdAt,
   }) async {
     final entryType = metadata?['type'] as String? ?? 'text';
-    final tags = <String>['daily'];
-    if (entryType == 'voice') tags.add('voice');
+    final tags = <String>[entryType == 'voice' ? 'spoken' : 'typed'];
     final note = await createNote(content: content, tags: tags, createdAt: createdAt);
     if (note == null) return null;
     return _noteToEntry(note);
@@ -463,7 +467,7 @@ class DailyApiService {
   }
 
   static JournalEntry _noteToEntry(Note note, {String? audioPath}) {
-    final isVoice = note.hasTag('voice');
+    final isVoice = note.hasTag('spoken');
     return JournalEntry(
       id: note.id,
       title: note.path ?? '',

--- a/lib/features/digest/providers/digest_providers.dart
+++ b/lib/features/digest/providers/digest_providers.dart
@@ -24,7 +24,7 @@ final digestNotesProvider = FutureProvider.autoDispose<List<Note>>((ref) async {
   final api = ref.watch(graphApiServiceProvider);
 
   final notes = await api.queryNotes(
-    tag: 'digest',
+    tag: 'reader',
     excludeTag: showArchived ? null : 'archived',
     sort: 'desc',
   );
@@ -82,18 +82,18 @@ final digestCountProvider = Provider<int>((ref) {
 /// Returns a map of display label → notes. Notes with only `#digest`
 /// go into an empty-string key (no section header). Sub-tags like
 /// `digest/summary` get a label like "Summary".
-Map<String, List<Note>> groupDigestBySubTag(List<Note> notes) {
+Map<String, List<Note>> groupReaderBySubTag(List<Note> notes) {
   final grouped = <String, List<Note>>{};
 
   for (final note in notes) {
-    final digestTag = note.tags.firstWhere(
-      (t) => t.startsWith('digest/'),
-      orElse: () => 'digest',
+    final readerTag = note.tags.firstWhere(
+      (t) => t.startsWith('reader/'),
+      orElse: () => 'reader',
     );
 
-    final label = digestTag == 'digest'
+    final label = readerTag == 'reader'
         ? ''
-        : _formatSubTagLabel(digestTag.substring('digest/'.length));
+        : _formatSubTagLabel(readerTag.substring('reader/'.length));
 
     grouped.putIfAbsent(label, () => []).add(note);
   }

--- a/lib/features/digest/screens/digest_screen.dart
+++ b/lib/features/digest/screens/digest_screen.dart
@@ -6,9 +6,9 @@ import 'package:parachute/core/theme/design_tokens.dart';
 import 'package:parachute/features/daily/journal/providers/journal_providers.dart';
 import '../providers/digest_providers.dart';
 
-/// Digest tab — inbox of AI-surfaced content.
+/// Reader tab — inbox of content to process.
 ///
-/// Shows notes tagged #digest. Pinned items float to top, grouped by sub-tag.
+/// Shows notes tagged #reader. Pinned items float to top, grouped by sub-tag.
 /// Archive toggle in header. Swipe to archive/unarchive, long-press to pin.
 class DigestScreen extends ConsumerStatefulWidget {
   const DigestScreen({super.key});
@@ -39,7 +39,7 @@ class _DigestScreenState extends ConsumerState<DigestScreen> {
             child: Row(
               children: [
                 Expanded(
-                  child: Text('Digest', style: theme.textTheme.headlineSmall),
+                  child: Text('Reader', style: theme.textTheme.headlineSmall),
                 ),
                 // Count badge
                 notesAsync.whenOrNull(
@@ -97,7 +97,7 @@ class _DigestScreenState extends ConsumerState<DigestScreen> {
   }
 
   Widget _buildNotesList(List<Note> notes) {
-    final grouped = groupDigestBySubTag(notes);
+    final grouped = groupReaderBySubTag(notes);
     final sortedKeys = grouped.keys.toList()..sort();
     final showHeaders = sortedKeys.length > 1 ||
         (sortedKeys.length == 1 && sortedKeys.first.isNotEmpty);
@@ -148,14 +148,14 @@ class _DigestScreenState extends ConsumerState<DigestScreen> {
             ),
             const SizedBox(height: 16),
             Text(
-              showArchived ? 'No digests' : 'No digests yet',
+              showArchived ? 'Nothing here' : 'Nothing to read yet',
               style: theme.textTheme.headlineSmall,
             ),
             const SizedBox(height: 8),
             Text(
               showArchived
                   ? 'Archived digests will appear here.'
-                  : 'AI-surfaced content will appear here as agents create digest notes.',
+                  : 'Content to read and process will appear here.',
               textAlign: TextAlign.center,
               style: theme.textTheme.bodyMedium?.copyWith(
                 color: theme.colorScheme.outline,
@@ -374,12 +374,12 @@ class _DigestCard extends ConsumerWidget {
 
   List<Widget> _buildSubTagChip(ThemeData theme, bool isDark) {
     final subTag = note.tags.firstWhere(
-      (t) => t.startsWith('digest/'),
+      (t) => t.startsWith('reader/'),
       orElse: () => '',
     );
     if (subTag.isEmpty) return [];
 
-    final label = subTag.substring('digest/'.length);
+    final label = subTag.substring('reader/'.length);
     return [
       Container(
         padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),

--- a/lib/features/vault/providers/vault_providers.dart
+++ b/lib/features/vault/providers/vault_providers.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:parachute/core/models/thing.dart';
+import 'package:parachute/core/providers/feature_flags_provider.dart'
+    show aiServerUrlProvider;
+import 'package:parachute/core/services/tag_service.dart';
+import 'package:parachute/features/daily/journal/providers/journal_providers.dart';
+
+/// Trigger to refresh vault data.
+final vaultRefreshTriggerProvider = StateProvider<int>((ref) => 0);
+
+/// Search query for the vault tab.
+final vaultSearchQueryProvider = StateProvider<String>((ref) => '');
+
+/// Active tag filter (null = show all).
+final vaultTagFilterProvider = StateProvider<String?>((ref) => null);
+
+/// Fetch all tags with counts from the server.
+final vaultTagsProvider = FutureProvider.autoDispose<List<TagInfo>>((ref) async {
+  ref.watch(vaultRefreshTriggerProvider);
+  await ref.watch(aiServerUrlProvider.future);
+  final tagService = ref.watch(tagServiceProvider);
+  return tagService.listTags();
+});
+
+/// Search notes across the full vault.
+final vaultSearchProvider = FutureProvider.autoDispose<List<Note>?>((ref) async {
+  final query = ref.watch(vaultSearchQueryProvider);
+  if (query.trim().isEmpty) return null;
+  await ref.watch(aiServerUrlProvider.future);
+  final api = ref.watch(graphApiServiceProvider);
+  return api.searchNotes(query);
+});
+
+/// Browse notes filtered by tag. Shows recent notes when no tag is selected.
+final vaultNotesProvider = FutureProvider.autoDispose<List<Note>>((ref) async {
+  ref.watch(vaultRefreshTriggerProvider);
+  await ref.watch(aiServerUrlProvider.future);
+  final api = ref.watch(graphApiServiceProvider);
+  final tagFilter = ref.watch(vaultTagFilterProvider);
+
+  final notes = await api.queryNotes(
+    tag: tagFilter,
+    sort: 'desc',
+    limit: 50,
+  );
+
+  if (notes != null) {
+    try {
+      final cache = await ref.read(noteLocalCacheProvider.future);
+      cache.putNotes(notes);
+    } catch (e) {
+      debugPrint('[VaultProviders] Cache write failed: $e');
+    }
+    return notes;
+  }
+
+  // Offline fallback
+  try {
+    final cache = await ref.read(noteLocalCacheProvider.future);
+    if (tagFilter != null) {
+      return cache.getNotesWithTag(tagFilter);
+    }
+    return [];
+  } catch (e) {
+    debugPrint('[VaultProviders] Cache read failed: $e');
+    return [];
+  }
+});

--- a/lib/features/vault/screens/vault_screen.dart
+++ b/lib/features/vault/screens/vault_screen.dart
@@ -1,0 +1,349 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:parachute/core/models/thing.dart';
+import 'package:parachute/core/screens/note_detail_screen.dart';
+import 'package:parachute/core/theme/design_tokens.dart';
+import '../providers/vault_providers.dart';
+
+/// Vault tab — search, browse tags, and explore all notes.
+class VaultScreen extends ConsumerStatefulWidget {
+  const VaultScreen({super.key});
+
+  @override
+  ConsumerState<VaultScreen> createState() => _VaultScreenState();
+}
+
+class _VaultScreenState extends ConsumerState<VaultScreen> {
+  final _searchController = TextEditingController();
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  void _onSearchChanged(String query) {
+    ref.read(vaultSearchQueryProvider.notifier).state = query;
+  }
+
+  void _selectTag(String? tag) {
+    ref.read(vaultTagFilterProvider.notifier).state = tag;
+  }
+
+  void _refresh() {
+    ref.read(vaultRefreshTriggerProvider.notifier).state++;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+    final searchQuery = ref.watch(vaultSearchQueryProvider);
+    final isSearching = searchQuery.trim().isNotEmpty;
+    final activeTag = ref.watch(vaultTagFilterProvider);
+
+    return Column(
+      children: [
+        SafeArea(
+          bottom: false,
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(16, 8, 8, 0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // Title row
+                Row(
+                  children: [
+                    Expanded(
+                      child: Text('Vault', style: theme.textTheme.headlineSmall),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 8),
+                // Search bar
+                TextField(
+                  controller: _searchController,
+                  decoration: InputDecoration(
+                    hintText: 'Search notes...',
+                    prefixIcon: const Icon(Icons.search, size: 20),
+                    suffixIcon: searchQuery.isNotEmpty
+                        ? IconButton(
+                            icon: const Icon(Icons.clear, size: 20),
+                            onPressed: () {
+                              _searchController.clear();
+                              _onSearchChanged('');
+                            },
+                          )
+                        : null,
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(Radii.sm),
+                      borderSide: BorderSide(
+                        color: (isDark ? BrandColors.nightTextSecondary : BrandColors.driftwood)
+                            .withValues(alpha: 0.3),
+                      ),
+                    ),
+                    contentPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                    isDense: true,
+                  ),
+                  onChanged: _onSearchChanged,
+                ),
+              ],
+            ),
+          ),
+        ),
+        const SizedBox(height: 4),
+        const Divider(height: 1),
+        // Content
+        Expanded(
+          child: isSearching ? _buildSearchResults() : _buildBrowseView(activeTag),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSearchResults() {
+    final resultsAsync = ref.watch(vaultSearchProvider);
+
+    return resultsAsync.when(
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (e, _) => Center(child: Text('Error: $e')),
+      data: (results) {
+        if (results == null || results.isEmpty) {
+          return Center(
+            child: Text(
+              results == null ? '' : 'No results found',
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: Theme.of(context).colorScheme.outline,
+                  ),
+            ),
+          );
+        }
+        return _buildNotesList(results);
+      },
+    );
+  }
+
+  Widget _buildBrowseView(String? activeTag) {
+    return Column(
+      children: [
+        // Tag chips
+        _buildTagBar(activeTag),
+        // Notes list
+        Expanded(
+          child: _buildFilteredNotes(),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildTagBar(String? activeTag) {
+    final tagsAsync = ref.watch(vaultTagsProvider);
+
+    return tagsAsync.when(
+      loading: () => const SizedBox(height: 48),
+      error: (_, __) => const SizedBox(height: 48),
+      data: (tags) {
+        if (tags.isEmpty) return const SizedBox.shrink();
+
+        final isDark = Theme.of(context).brightness == Brightness.dark;
+        // Filter out system tags from the chip bar
+        final displayTags = tags.where((t) =>
+            t.tag != 'view' && t.tag != 'pinned' && t.tag != 'archived'
+        ).toList();
+
+        return SizedBox(
+          height: 48,
+          child: ListView(
+            scrollDirection: Axis.horizontal,
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+            children: [
+              // "All" chip
+              Padding(
+                padding: const EdgeInsets.only(right: 6),
+                child: FilterChip(
+                  label: const Text('All'),
+                  selected: activeTag == null,
+                  onSelected: (_) => _selectTag(null),
+                  visualDensity: VisualDensity.compact,
+                  selectedColor: (isDark ? BrandColors.nightTurquoise : BrandColors.turquoise)
+                      .withValues(alpha: 0.2),
+                ),
+              ),
+              ...displayTags.map((tag) => Padding(
+                    padding: const EdgeInsets.only(right: 6),
+                    child: FilterChip(
+                      label: Text('${tag.tag} (${tag.count})'),
+                      selected: activeTag == tag.tag,
+                      onSelected: (_) => _selectTag(
+                        activeTag == tag.tag ? null : tag.tag,
+                      ),
+                      visualDensity: VisualDensity.compact,
+                      selectedColor: (isDark ? BrandColors.nightTurquoise : BrandColors.turquoise)
+                          .withValues(alpha: 0.2),
+                    ),
+                  )),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildFilteredNotes() {
+    final notesAsync = ref.watch(vaultNotesProvider);
+
+    return notesAsync.when(
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (e, _) => Center(child: Text('Error: $e')),
+      data: (notes) {
+        if (notes.isEmpty) {
+          return _buildEmpty();
+        }
+        return RefreshIndicator(
+          onRefresh: () async {
+            _refresh();
+            await ref.read(vaultNotesProvider.future);
+          },
+          child: _buildNotesList(notes),
+        );
+      },
+    );
+  }
+
+  Widget _buildNotesList(List<Note> notes) {
+    return ListView.separated(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      itemCount: notes.length,
+      separatorBuilder: (_, __) => const Divider(height: 1, indent: 16, endIndent: 16),
+      itemBuilder: (context, index) => _VaultNoteItem(
+        note: notes[index],
+        onChanged: _refresh,
+      ),
+    );
+  }
+
+  Widget _buildEmpty() {
+    final theme = Theme.of(context);
+    final activeTag = ref.read(vaultTagFilterProvider);
+
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(Icons.inventory_2_outlined, size: 48, color: theme.colorScheme.outline),
+            const SizedBox(height: 16),
+            Text(
+              activeTag != null ? 'No #$activeTag notes' : 'Vault is empty',
+              style: theme.textTheme.headlineSmall,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              activeTag != null
+                  ? 'No notes with this tag yet.'
+                  : 'Notes will appear here as you capture and create.',
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.outline,
+              ),
+            ),
+            const SizedBox(height: 24),
+            OutlinedButton.icon(
+              onPressed: _refresh,
+              icon: const Icon(Icons.refresh, size: 18),
+              label: const Text('Refresh'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _VaultNoteItem extends StatelessWidget {
+  final Note note;
+  final VoidCallback onChanged;
+
+  const _VaultNoteItem({required this.note, required this.onChanged});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+    final title = note.path ?? '';
+    final preview = note.content.length > 120
+        ? '${note.content.substring(0, 120)}...'
+        : note.content;
+    final date = note.updatedAt ?? note.createdAt;
+
+    return ListTile(
+      contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 2),
+      title: Row(
+        children: [
+          Expanded(
+            child: Text(
+              title.isNotEmpty ? title : preview,
+              maxLines: title.isNotEmpty ? 1 : 2,
+              overflow: TextOverflow.ellipsis,
+              style: title.isNotEmpty ? theme.textTheme.titleMedium : null,
+            ),
+          ),
+        ],
+      ),
+      subtitle: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (title.isNotEmpty)
+            Text(preview, maxLines: 1, overflow: TextOverflow.ellipsis),
+          const SizedBox(height: 4),
+          Wrap(
+            spacing: 4,
+            runSpacing: 2,
+            children: note.tags
+                .where((t) => t != 'pinned' && t != 'archived')
+                .map((t) => Container(
+                      padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 1),
+                      decoration: BoxDecoration(
+                        color: BrandColors.forest.withValues(alpha: 0.1),
+                        borderRadius: BorderRadius.circular(3),
+                      ),
+                      child: Text(
+                        '#$t',
+                        style: theme.textTheme.labelSmall?.copyWith(
+                          color: BrandColors.forest,
+                          fontSize: 10,
+                        ),
+                      ),
+                    ))
+                .toList(),
+          ),
+        ],
+      ),
+      trailing: Text(
+        _shortDate(date),
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: isDark ? BrandColors.nightTextSecondary : BrandColors.driftwood,
+        ),
+      ),
+      onTap: () {
+        Navigator.of(context).push(
+          MaterialPageRoute(
+            builder: (_) => NoteDetailScreen(
+              note: note,
+              onChanged: onChanged,
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  static String _shortDate(DateTime dt) {
+    final months = [
+      'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+      'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+    ];
+    return '${months[dt.month - 1]} ${dt.day}';
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -22,7 +22,7 @@ import 'features/daily/recorder/providers/omi_providers.dart';
 import 'features/daily/journal/providers/journal_providers.dart';
 import 'features/digest/screens/digest_screen.dart';
 import 'features/digest/providers/digest_providers.dart';
-import 'features/docs/screens/docs_screen.dart';
+import 'features/vault/screens/vault_screen.dart';
 import 'features/settings/screens/settings_screen.dart';
 import 'features/onboarding/screens/onboarding_screen.dart';
 
@@ -207,9 +207,9 @@ class _DailyShellState extends ConsumerState<_DailyShell> with WidgetsBindingObs
   }
 
   static const _tabs = [
-    _TabDef('Digest', Icons.auto_awesome_outlined, Icons.auto_awesome),
-    _TabDef('Daily', Icons.edit_note_outlined, Icons.edit_note),
-    _TabDef('Docs', Icons.description_outlined, Icons.description),
+    _TabDef('Reader', Icons.auto_awesome_outlined, Icons.auto_awesome),
+    _TabDef('Capture', Icons.edit_note_outlined, Icons.edit_note),
+    _TabDef('Vault', Icons.inventory_2_outlined, Icons.inventory_2),
   ];
 
   @override
@@ -245,7 +245,7 @@ class _DailyShellState extends ConsumerState<_DailyShell> with WidgetsBindingObs
               children: const [
                 DigestScreen(),
                 HomeScreen(),
-                DocsScreen(),
+                VaultScreen(),
               ],
             ),
           ),


### PR DESCRIPTION
## Summary
Major tab and tag restructure for beta:

- **Reader** (was Digest) — shows `#reader` content. AI briefs, articles, digests to process.
- **Capture** (was Daily) — shows `#spoken`, `#typed`, `#clipped` grouped by date. Voice memos, typed thoughts, clipped quotes.
- **Vault** (replaces Docs) — search bar + tag chip filter bar + browse all notes. Docs live here as a tag filter.

Tag vocabulary simplified to flat, composable tags:
- `#spoken` (was `#daily` + `#voice`)
- `#typed` (was `#daily`)  
- `#clipped` (new)
- `#reader` (was `#digest`)
- `#doc`, `#view`, `#pinned`, `#archived` unchanged
- Dropped `#daily` — not needed, date comes from `createdAt`

## Test plan
- [ ] Three tabs: Reader / Capture / Vault
- [ ] Record voice note → tagged `#spoken`, appears in Capture tab
- [ ] Type a note → tagged `#typed`, appears in Capture tab
- [ ] Vault tab shows search bar, tag chips, all notes
- [ ] Filter by tag in Vault tab
- [ ] Reader tab shows `#reader` notes
- [ ] `flutter analyze` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)