### PR TITLE
fix: use OR tag queries and sync ingest (vault#14)

### DIFF
--- a/lib/features/daily/journal/screens/journal_screen.dart
+++ b/lib/features/daily/journal/screens/journal_screen.dart
@@ -507,52 +507,22 @@ class _JournalScreenState extends ConsumerState<JournalScreen> with WidgetsBindi
     if (ingestResult != null && mounted) {
       debugPrint('[JournalScreen] Ingest succeeded: ${ingestResult.id}, content: ${ingestResult.content.length} chars');
 
-      // Cache the entry (may have empty content if transcription is async)
-      final entry = JournalEntry(
-        id: ingestResult.id,
-        title: ingestResult.path ?? '',
-        content: ingestResult.content,
-        type: JournalEntryType.voice,
-        createdAt: ingestResult.createdAt,
-        audioPath: ingestResult.content.isEmpty ? localAudioPath : null,
-        durationSeconds: duration,
-      );
+      // Ingest with sync=true returns the note with transcript already populated
       await _appendEntryToCache(
-        entry,
+        JournalEntry(
+          id: ingestResult.id,
+          title: ingestResult.path ?? '',
+          content: ingestResult.content,
+          type: JournalEntryType.voice,
+          createdAt: ingestResult.createdAt,
+          durationSeconds: duration,
+        ),
         content: ingestResult.content,
         type: JournalEntryType.voice,
-        audioPath: ingestResult.content.isEmpty ? localAudioPath : null,
         durationSeconds: duration,
       );
 
-      // If vault returned content (sync transcription), we're done
-      if (ingestResult.content.isNotEmpty) {
-        try { await File(localAudioPath).delete(); } catch (_) {}
-        return;
-      }
-
-      // Vault returned empty content — transcription is async or unavailable.
-      // Transcribe client-side using the local audio file, then update the note.
-      debugPrint('[JournalScreen] Ingest returned empty content, transcribing client-side...');
-      final transcriptionService = ref.read(transcriptionApiServiceProvider);
-      if (transcriptionService != null && useServerTranscription) {
-        try {
-          final transcript = await transcriptionService.transcribe(localAudioPath);
-          if (transcript.isNotEmpty && mounted) {
-            await api.updateNote(ingestResult.id, content: transcript);
-            final updated = entry.copyWith(content: transcript);
-            if (_cachedJournal != null) {
-              setState(() {
-                _cachedJournal = _cachedJournal!.updateEntry(updated);
-              });
-            }
-            debugPrint('[JournalScreen] Client-side transcription complete: ${transcript.length} chars');
-          }
-        } catch (e) {
-          debugPrint('[JournalScreen] Client-side transcription failed: $e');
-        }
-      }
-
+      // Clean up local audio — server has it now
       try { await File(localAudioPath).delete(); } catch (_) {}
       return;
     }

--- a/lib/features/daily/journal/services/daily_api_service.dart
+++ b/lib/features/daily/journal/services/daily_api_service.dart
@@ -83,43 +83,35 @@ class DailyApiService {
   /// Fetch notes for a specific date (YYYY-MM-DD).
   ///
   /// Queries for capture-type tags (spoken, typed, clipped) by default.
-  /// The vault doesn't support OR queries, so we query each tag separately
-  /// and merge + deduplicate the results.
+  /// Uses comma-separated OR query: `?tag=spoken,typed,clipped`.
   /// Returns `null` on network error — callers should fall back to cache.
   /// Returns `[]` when the server responds with no notes — authoritative empty.
   Future<List<Note>?> getNotes({required String date, String? tag}) async {
-    final tags = tag != null ? [tag] : captureTags;
     final nextDate = _nextDate(date);
-
+    final uri = Uri.parse('$baseUrl$_apiPrefix/notes').replace(
+      queryParameters: {
+        'tag': tag ?? captureTags.join(','),
+        'date_from': '${date}T00:00:00.000Z',
+        'date_to': '${nextDate}T00:00:00.000Z',
+        'limit': '100',
+      },
+    );
+    debugPrint('[DailyApiService] GET $uri');
     try {
-      final allNotes = <String, Note>{};
-      for (final t in tags) {
-        final uri = Uri.parse('$baseUrl$_apiPrefix/notes').replace(
-          queryParameters: {
-            'tag': t,
-            'date_from': '${date}T00:00:00.000Z',
-            'date_to': '${nextDate}T00:00:00.000Z',
-            'limit': '100',
-          },
-        );
-        final response = await _client
-            .get(uri, headers: _headers)
-            .timeout(_timeout);
+      final response = await _client
+          .get(uri, headers: _headers)
+          .timeout(_timeout);
 
-        if (response.statusCode >= 200 && response.statusCode < 300) {
-          onReachabilityChanged?.call(true);
-          final data = jsonDecode(response.body) as List<dynamic>;
-          for (final json in data) {
-            final note = Note.fromJson(json as Map<String, dynamic>);
-            allNotes[note.id] = note; // Deduplicate by ID
-          }
-        }
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        debugPrint('[DailyApiService] GET notes ${response.statusCode}');
+        return null;
       }
 
-      // Sort by createdAt descending
-      final result = allNotes.values.toList()
-        ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
-      return result;
+      onReachabilityChanged?.call(true);
+      final data = jsonDecode(response.body) as List<dynamic>;
+      return data
+          .map((json) => Note.fromJson(json as Map<String, dynamic>))
+          .toList();
     } catch (e) {
       debugPrint('[DailyApiService] getNotes error (offline?): $e');
       onReachabilityChanged?.call(false);
@@ -248,6 +240,7 @@ class DailyApiService {
       request.fields['created_at'] = createdAt.toIso8601String();
       request.fields['tags'] = 'spoken';
       request.fields['transcribe'] = transcribe.toString();
+      if (transcribe) request.fields['sync'] = 'true';
       request.fields['metadata'] = jsonEncode({
         'source': 'voice-memo',
         'duration_seconds': durationSeconds,


### PR DESCRIPTION
## Summary
Depends on ParachuteComputer/parachute-vault#14.

- **OR tag queries**: `getNotes` now uses single request `?tag=spoken,typed,clipped` instead of 3 separate requests per date. 3x fewer HTTP calls on every Capture tab load.
- **Sync ingest**: Sends `sync=true` on `/api/ingest` so vault blocks until transcription completes. Returns note with content populated. Removed the client-side transcription follow-up — one request does everything.
- Net -37 lines.

## Test plan
- [ ] Capture tab loads notes in one request
- [ ] Record voice note → ingest returns with transcript populated
- [ ] No follow-up transcribe call needed
- [ ] `flutter analyze` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)