### PR TITLE
fix: filter cache by capture tags to prevent reader notes flashing

### DIFF
--- a/lib/core/services/note_local_cache.dart
+++ b/lib/core/services/note_local_cache.dart
@@ -74,14 +74,30 @@ class NoteLocalCache {
   /// Return all visible notes for a date range, oldest first.
   ///
   /// Excludes pending_delete notes. Includes pending_create and pending_edit.
-  List<Note> getNotesForDate(String dateFrom, String dateTo) {
+  /// When [tags] is provided, only returns notes matching at least one of those tags.
+  List<Note> getNotesForDate(String dateFrom, String dateTo, {List<String>? tags}) {
     try {
+      final conditions = <String>[
+        "created_at >= ?",
+        "created_at < ?",
+        "COALESCE(sync_state, 'synced') != 'pending_delete'",
+      ];
+      final params = <Object>[
+        '${dateFrom}T00:00:00.000Z',
+        '${dateTo}T00:00:00.000Z',
+      ];
+
+      if (tags != null && tags.isNotEmpty) {
+        final tagClauses = tags.map((_) => "tags_json LIKE ?").join(' OR ');
+        conditions.add("($tagClauses)");
+        for (final tag in tags) {
+          params.add('%"$tag"%');
+        }
+      }
+
       final rows = _db.select(
-        "SELECT * FROM notes "
-        "WHERE created_at >= ? AND created_at < ? "
-        "AND COALESCE(sync_state, 'synced') != 'pending_delete' "
-        "ORDER BY created_at ASC",
-        ['${dateFrom}T00:00:00.000Z', '${dateTo}T00:00:00.000Z'],
+        "SELECT * FROM notes WHERE ${conditions.join(' AND ')} ORDER BY created_at ASC",
+        params,
       );
       return rows.map(_rowToNote).toList();
     } catch (e) {

--- a/lib/features/daily/journal/providers/journal_providers.dart
+++ b/lib/features/daily/journal/providers/journal_providers.dart
@@ -168,7 +168,7 @@ Future<JournalDay> _loadJournal(
   final cache = await ref.watch(noteLocalCacheProvider.future);
 
   // Phase 1 — serve from cache immediately (excludes pending_delete).
-  final cachedNotes = cache.getNotesForDate(dateStr, nextDateStr);
+  final cachedNotes = cache.getNotesForDate(dateStr, nextDateStr, tags: DailyApiService.captureTags);
   if (cachedNotes.isNotEmpty) {
     final entries = cachedNotes.map((note) {
       final audioPath = cache.getAudioPath(note.id);
@@ -180,7 +180,7 @@ Future<JournalDay> _loadJournal(
   // Phase 2 — flush pending ops and fetch from server (only when online).
   final isAvailable = ref.watch(isServerAvailableProvider);
   if (!isAvailable) {
-    final freshNotes = cache.getNotesForDate(dateStr, nextDateStr);
+    final freshNotes = cache.getNotesForDate(dateStr, nextDateStr, tags: DailyApiService.captureTags);
     final entries = freshNotes.map((note) {
       final audioPath = cache.getAudioPath(note.id);
       return _noteToEntry(note, audioPath: audioPath);
@@ -217,7 +217,7 @@ Future<JournalDay> _loadJournal(
   }
 
   // Re-read cache: merged truth.
-  final freshNotes = cache.getNotesForDate(dateStr, nextDateStr);
+  final freshNotes = cache.getNotesForDate(dateStr, nextDateStr, tags: DailyApiService.captureTags);
   final entries = freshNotes.map((note) {
     final audioPath = cache.getAudioPath(note.id);
     return _noteToEntry(note, audioPath: audioPath);


### PR DESCRIPTION
## Summary
Local cache was returning ALL notes for a date (including #reader) during the cache-first phase, causing a brief flash of reader notes in the Capture tab before the server response replaced them.

Fix: `getNotesForDate` now accepts optional `tags` parameter. Journal provider passes `captureTags` (spoken, typed, clipped) so cache only serves capture-type notes.

## Test plan
- [ ] Navigate between dates — no flash of reader/digest notes
- [ ] Capture tab shows correct notes from cache when offline

🤖 Generated with [Claude Code](https://claude.com/claude-code)