### PR TITLE
refactor: simplify to #captured + metadata, drop per-type tags

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ Three-tab layout: **Reader**, **Capture**, **Vault**.
 | Tab | Query | Description |
 |-----|-------|-------------|
 | **Reader** | `#reader NOT #archived` | Content to process — AI briefs, articles, digests |
-| **Capture** | `#spoken OR #typed OR #clipped`, grouped by date | Voice memos, typed thoughts, clipped quotes |
+| **Capture** | `#captured`, grouped by date | Voice memos, typed thoughts, clipped quotes |
 | **Vault** | Search + tag browser + saved views | Browse all notes, filter by tag, saved views |
 
 ## Directory Structure
@@ -81,23 +81,20 @@ Everything is a **Note**, differentiated by flat **Tags**:
 
 ### Built-in Tags
 
-**Content type (what it is):**
+**Content tags:**
 ```
-#spoken     — transcribed from voice
-#typed      — written by hand
-#clipped    — grabbed from elsewhere (quote, link, photo)
-#doc        — long-form document (blog draft, meeting notes, list)
+#captured   — user-created content (voice memos, typed notes, clips)
 #reader     — content to process (AI briefs, articles, digests)
 #view       — saved view definition (query + display config)
 ```
 
-**State (applies to any note):**
+**State tags (apply to any note):**
 ```
 #pinned     — kept prominent
 #archived   — user is done with this
 ```
 
-Tags are flat and composable. A note can have multiple tags. The Capture tab shows `#spoken`, `#typed`, `#clipped` grouped by date. The Reader tab shows `#reader`. The Vault tab shows everything via search and tag filtering. Tags use optional `/` hierarchy for sub-categories: `#doc/meeting`, `#reader/summary`.
+Tags are minimal and flat. Content type details (spoken vs typed vs clipped) live in note metadata (`metadata.source`), not tags. The Capture tab shows `#captured` grouped by date. The Reader tab shows `#reader`. The Vault tab shows everything via search and tag filtering. Tags use optional `/` hierarchy for sub-categories: `#reader/summary`.
 
 ### Server API
 

--- a/lib/core/models/thing.dart
+++ b/lib/core/models/thing.dart
@@ -25,17 +25,11 @@ class Note {
 
   // ---- Type checks ----
 
-  bool get isSpoken => hasTag('spoken');
-  bool get isTyped => hasTag('typed');
-  bool get isClipped => hasTag('clipped');
-  bool get isDoc => hasTag('doc');
+  bool get isCaptured => hasTag('captured');
   bool get isReader => hasTag('reader');
   bool get isView => hasTag('view');
   bool get isPinned => hasTag('pinned');
   bool get isArchived => hasTag('archived');
-
-  /// Whether this is a capture-type note (spoken, typed, or clipped).
-  bool get isCapture => isSpoken || isTyped || isClipped;
 
   // ---- Serialization ----
 

--- a/lib/features/daily/journal/providers/journal_providers.dart
+++ b/lib/features/daily/journal/providers/journal_providers.dart
@@ -143,7 +143,7 @@ class _SelectedJournalNotifier extends AutoDisposeAsyncNotifier<JournalDay> {
 /// This is the boundary between the v3 data model (Note + tags) and the
 /// Daily tab's specialized view model (JournalEntry with type, audio, etc.).
 JournalEntry _noteToEntry(Note note, {String? audioPath, bool isPending = false}) {
-  final isVoice = note.hasTag('spoken');
+  final isVoice = audioPath != null;
   return JournalEntry(
     id: note.id,
     title: note.path ?? '',
@@ -168,7 +168,7 @@ Future<JournalDay> _loadJournal(
   final cache = await ref.watch(noteLocalCacheProvider.future);
 
   // Phase 1 — serve from cache immediately (excludes pending_delete).
-  final cachedNotes = cache.getNotesForDate(dateStr, nextDateStr, tags: DailyApiService.captureTags);
+  final cachedNotes = cache.getNotesForDate(dateStr, nextDateStr, tags: [DailyApiService.captureTag]);
   if (cachedNotes.isNotEmpty) {
     final entries = cachedNotes.map((note) {
       final audioPath = cache.getAudioPath(note.id);
@@ -180,7 +180,7 @@ Future<JournalDay> _loadJournal(
   // Phase 2 — flush pending ops and fetch from server (only when online).
   final isAvailable = ref.watch(isServerAvailableProvider);
   if (!isAvailable) {
-    final freshNotes = cache.getNotesForDate(dateStr, nextDateStr, tags: DailyApiService.captureTags);
+    final freshNotes = cache.getNotesForDate(dateStr, nextDateStr, tags: [DailyApiService.captureTag]);
     final entries = freshNotes.map((note) {
       final audioPath = cache.getAudioPath(note.id);
       return _noteToEntry(note, audioPath: audioPath);
@@ -202,7 +202,7 @@ Future<JournalDay> _loadJournal(
         dateStr, nextDateStr, serverNotes.map((n) => n.id).toSet(),
       );
       // Fetch and cache audio paths for voice notes (parallel).
-      final voiceNotes = serverNotes.where((n) => n.isSpoken).toList();
+      final voiceNotes = serverNotes.where((n) => n.isCaptured).toList();
       if (voiceNotes.isNotEmpty) {
         final audioPaths = await Future.wait(
           voiceNotes.map((n) => api.getAudioPath(n.id)),
@@ -217,7 +217,7 @@ Future<JournalDay> _loadJournal(
   }
 
   // Re-read cache: merged truth.
-  final freshNotes = cache.getNotesForDate(dateStr, nextDateStr, tags: DailyApiService.captureTags);
+  final freshNotes = cache.getNotesForDate(dateStr, nextDateStr, tags: [DailyApiService.captureTag]);
   final entries = freshNotes.map((note) {
     final audioPath = cache.getAudioPath(note.id);
     return _noteToEntry(note, audioPath: audioPath);
@@ -240,10 +240,8 @@ Future<void> _flushPendingOps(
     final pendingCreates = cache.getPendingCreates();
     for (final note in pendingCreates) {
       final audioPath = cache.getAudioPath(note.id);
-      final isVoice = note.hasTag('spoken');
-
       // Voice notes with local audio: use ingest endpoint (atomic)
-      if (isVoice && audioPath != null && audioPath.startsWith('/')) {
+      if (audioPath != null && audioPath.startsWith('/')) {
         final audioFile = File(audioPath);
         if (!await audioFile.exists()) {
           debugPrint('[FlushOps] Audio file missing for ${note.id}, skipping');
@@ -269,7 +267,7 @@ Future<void> _flushPendingOps(
       }
 
       // Non-voice notes or notes with server audio paths: create directly
-      final tags = note.tags.isNotEmpty ? note.tags : ['typed'];
+      final tags = note.tags.isNotEmpty ? note.tags : ['captured'];
       final serverNote = await api.createNote(
         content: note.content,
         tags: tags,

--- a/lib/features/daily/journal/screens/journal_screen.dart
+++ b/lib/features/daily/journal/screens/journal_screen.dart
@@ -356,14 +356,14 @@ class _JournalScreenState extends ConsumerState<JournalScreen> with WidgetsBindi
         id: entry.id,
         content: entry.content,
         createdAt: entry.createdAt,
-        tags: entry.tags ?? ['typed'],
+        tags: entry.tags ?? ['captured'],
       );
       cache.putNotes([note]);
     } else {
       // Offline — save to cache as pending_create
       final cache = await ref.read(noteLocalCacheProvider.future);
       final localId = 'pending-${DateTime.now().millisecondsSinceEpoch}';
-      final tags = <String>[type == JournalEntryType.voice ? 'spoken' : 'typed'];
+      final tags = <String>['captured'];
       final pendingNote = Note(id: localId, content: content, createdAt: DateTime.now(), tags: tags);
       cache.insertPendingCreate(pendingNote, audioPath: audioPath);
       final pending = JournalEntry(
@@ -385,7 +385,7 @@ class _JournalScreenState extends ConsumerState<JournalScreen> with WidgetsBindi
 
   static String _entryTypeString(JournalEntryType type) {
     switch (type) {
-      case JournalEntryType.voice: return 'spoken';
+      case JournalEntryType.voice: return 'voice';
       case JournalEntryType.photo: return 'photo';
       case JournalEntryType.handwriting: return 'handwriting';
       case JournalEntryType.linked: return 'linked';
@@ -417,7 +417,7 @@ class _JournalScreenState extends ConsumerState<JournalScreen> with WidgetsBindi
     // Step 1: Save to cache as pending_create — content is now safe
     final cache = await ref.read(noteLocalCacheProvider.future);
     final localId = 'pending-${DateTime.now().millisecondsSinceEpoch}';
-    final tags = <String>[type == JournalEntryType.voice ? 'spoken' : 'typed'];
+    final tags = <String>['captured'];
     final pendingNote = Note(id: localId, content: content, createdAt: DateTime.now(), tags: tags);
     cache.insertPendingCreate(pendingNote, audioPath: audioPath);
     final pending = JournalEntry(
@@ -462,7 +462,7 @@ class _JournalScreenState extends ConsumerState<JournalScreen> with WidgetsBindi
       if (!mounted) return;
       final serverNote = Note(
         id: entry.id, content: entry.content,
-        createdAt: entry.createdAt, tags: entry.tags ?? ['typed'],
+        createdAt: entry.createdAt, tags: entry.tags ?? ['captured'],
       );
       cache.putNotes([serverNote]);
 

--- a/lib/features/daily/journal/services/daily_api_service.dart
+++ b/lib/features/daily/journal/services/daily_api_service.dart
@@ -77,8 +77,8 @@ class DailyApiService {
   // Journal Entry CRUD — backed by Notes tagged "daily"
   // ===========================================================================
 
-  /// Tags that represent capture-type notes (shown in the Capture tab).
-  static const captureTags = ['spoken', 'typed', 'clipped'];
+  /// Tag for capture-type notes (shown in the Capture tab).
+  static const captureTag = 'captured';
 
   /// Fetch notes for a specific date (YYYY-MM-DD).
   ///
@@ -90,7 +90,7 @@ class DailyApiService {
     final nextDate = _nextDate(date);
     final uri = Uri.parse('$baseUrl$_apiPrefix/notes').replace(
       queryParameters: {
-        'tag': tag ?? captureTags.join(','),
+        'tag': tag ?? captureTag,
         'date_from': '${date}T00:00:00.000Z',
         'date_to': '${nextDate}T00:00:00.000Z',
         'limit': '100',
@@ -125,7 +125,7 @@ class DailyApiService {
   /// flushing offline-created entries). If omitted, the server sets it.
   Future<Note?> createNote({
     required String content,
-    List<String> tags = const ['typed'],
+    List<String> tags = const ['captured'],
     DateTime? createdAt,
   }) async {
     final uri = Uri.parse('$baseUrl$_apiPrefix/notes');
@@ -238,7 +238,7 @@ class DailyApiService {
 
       // Fields
       request.fields['created_at'] = createdAt.toIso8601String();
-      request.fields['tags'] = 'spoken';
+      request.fields['tags'] = 'captured';
       request.fields['transcribe'] = transcribe.toString();
       if (transcribe) request.fields['sync'] = 'true';
       request.fields['metadata'] = jsonEncode({
@@ -323,7 +323,7 @@ class DailyApiService {
     // Create a note tagged daily + voice
     final note = await createNote(
       content: '',
-      tags: ['spoken'],
+      tags: ['captured'],
     );
 
     // Attach the audio file to the note
@@ -396,9 +396,7 @@ class DailyApiService {
     final entries = <JournalEntry>[];
     for (final note in notes) {
       String? audioPath;
-      if (note.isSpoken) {
-        audioPath = await getAudioPath(note.id);
-      }
+      audioPath = await getAudioPath(note.id);
       entries.add(_noteToEntry(note, audioPath: audioPath));
     }
     return entries;
@@ -410,8 +408,7 @@ class DailyApiService {
     Map<String, dynamic>? metadata,
     DateTime? createdAt,
   }) async {
-    final entryType = metadata?['type'] as String? ?? 'text';
-    final tags = <String>[entryType == 'voice' ? 'spoken' : 'typed'];
+    final tags = <String>['captured'];
     final note = await createNote(content: content, tags: tags, createdAt: createdAt);
     if (note == null) return null;
     return _noteToEntry(note);
@@ -469,7 +466,7 @@ class DailyApiService {
   }
 
   static JournalEntry _noteToEntry(Note note, {String? audioPath}) {
-    final isVoice = note.hasTag('spoken');
+    final isVoice = audioPath != null;
     return JournalEntry(
       id: note.id,
       title: note.path ?? '',


### PR DESCRIPTION
## Summary
Collapse #spoken/#typed/#clipped into single #captured tag. Content type lives in metadata.source.

5 tags total: #captured, #reader, #view, #pinned, #archived

Vault data already migrated (591 notes → #captured).

## Test plan
- [ ] Capture tab shows all notes
- [ ] New voice/typed notes tagged #captured
- [ ] Voice detection works via audio attachment

🤖 Generated with [Claude Code](https://claude.com/claude-code)