### PR TITLE
fix: force refresh after sync ingest

### DIFF
--- a/lib/features/daily/journal/screens/journal_screen.dart
+++ b/lib/features/daily/journal/screens/journal_screen.dart
@@ -507,23 +507,14 @@ class _JournalScreenState extends ConsumerState<JournalScreen> with WidgetsBindi
     if (ingestResult != null && mounted) {
       debugPrint('[JournalScreen] Ingest succeeded: ${ingestResult.id}, content: ${ingestResult.content.length} chars');
 
-      // Ingest with sync=true returns the note with transcript already populated
-      await _appendEntryToCache(
-        JournalEntry(
-          id: ingestResult.id,
-          title: ingestResult.path ?? '',
-          content: ingestResult.content,
-          type: JournalEntryType.voice,
-          createdAt: ingestResult.createdAt,
-          durationSeconds: duration,
-        ),
-        content: ingestResult.content,
-        type: JournalEntryType.voice,
-        durationSeconds: duration,
-      );
-
       // Clean up local audio — server has it now
       try { await File(localAudioPath).delete(); } catch (_) {}
+
+      // Force a full refresh from server — the note is there now.
+      // Don't use _appendEntryToCache because the sync ingest takes long enough
+      // that the journal state may have changed while we were waiting.
+      ref.invalidate(selectedJournalProvider);
+      ref.read(journalRefreshTriggerProvider.notifier).state++;
       return;
     }
 


### PR DESCRIPTION
## Summary
After sync ingest returns (10-30s), force a full provider refresh instead of trying to append to potentially stale cached journal state. The note is already on the server with transcript.

## Test plan
- [ ] Record voice note → after transcription completes, note appears in Capture tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)