### PR TITLE
fix: TagService parsing — vault returns raw list with 'name' field

### DIFF
--- a/lib/core/services/tag_service.dart
+++ b/lib/core/services/tag_service.dart
@@ -52,8 +52,11 @@ class TagService {
         debugPrint('[TagService] listTags ${response.statusCode}');
         return [];
       }
-      final decoded = jsonDecode(response.body) as Map<String, dynamic>;
-      final List<dynamic> data = decoded['tags'] as List<dynamic>? ?? [];
+      final decoded = jsonDecode(response.body);
+      // API returns a raw list: [{"name": "tag", "count": 5}, ...]
+      final List<dynamic> data = decoded is List
+          ? decoded
+          : (decoded as Map<String, dynamic>)['tags'] as List<dynamic>? ?? [];
       return data
           .map((j) => TagInfo.fromJson(j as Map<String, dynamic>))
           .toList();
@@ -121,7 +124,7 @@ class TagInfo {
 
   factory TagInfo.fromJson(Map<String, dynamic> json) {
     return TagInfo(
-      tag: json['tag'] as String? ?? '',
+      tag: json['name'] as String? ?? json['tag'] as String? ?? '',
       description: json['description'] as String? ?? '',
       count: (json['count'] as num?)?.toInt() ?? 0,
     );


### PR DESCRIPTION
## Summary
Vault API returns `[{"name":"captured","count":591}]` but TagService expected `{"tags":[{"tag":"captured",...}]}`. Fixed response shape handling and field name.

## Test plan
- [ ] Vault tab shows correct note/tag counts
- [ ] Tag cards appear with correct names and counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)