### PR TITLE
fix: handle malformed date strings in Note.fromJson

### DIFF
--- a/lib/core/models/thing.dart
+++ b/lib/core/models/thing.dart
@@ -34,14 +34,15 @@ class Note {
   // ---- Serialization ----
 
   factory Note.fromJson(Map<String, dynamic> json) {
+    final now = DateTime.now();
+    final createdRaw = json['createdAt'] as String?;
+    final updatedRaw = json['updatedAt'] as String?;
     return Note(
       id: json['id'] as String,
       content: json['content'] as String? ?? '',
       path: json['path'] as String?,
-      createdAt: DateTime.parse(json['createdAt'] as String),
-      updatedAt: json['updatedAt'] != null
-          ? DateTime.parse(json['updatedAt'] as String)
-          : null,
+      createdAt: (createdRaw != null ? DateTime.tryParse(createdRaw) : null) ?? now,
+      updatedAt: updatedRaw != null ? DateTime.tryParse(updatedRaw) : null,
       tags: (json['tags'] as List<dynamic>?)
               ?.map((t) => t as String)
               .toList() ??


### PR DESCRIPTION
## Summary
- Use `DateTime.tryParse` instead of `DateTime.parse` in `Note.fromJson` so notes with invalid `createdAt`/`updatedAt` values don't crash the app
- Falls back to `DateTime.now()` for malformed `createdAt`, `null` for malformed `updatedAt`
- Fixes the "invalid date format" error when drilling into #captured in the Vault tab (10 old notes have timestamps like `2026-02-25T708:00.000Z`)

## Test plan
- [ ] Tap #captured tag card in Vault tab — should load without error
- [ ] Notes with bad dates appear (sorted to recent) instead of crashing
- [ ] Normal notes with valid dates still parse correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)