### PR TITLE
feat: align Daily app with vault backend API (#48)

### DIFF
--- a/lib/core/models/thing.dart
+++ b/lib/core/models/thing.dart
@@ -6,6 +6,7 @@ class Note {
   final String? path;
   final DateTime createdAt;
   final DateTime? updatedAt;
+  final Map<String, dynamic> metadata;
   final List<String> tags;
   final List<NoteLink> links;
 
@@ -15,6 +16,7 @@ class Note {
     this.path,
     required this.createdAt,
     this.updatedAt,
+    this.metadata = const {},
     this.tags = const [],
     this.links = const [],
   });
@@ -43,6 +45,7 @@ class Note {
       path: json['path'] as String?,
       createdAt: (createdRaw != null ? DateTime.tryParse(createdRaw) : null) ?? now,
       updatedAt: updatedRaw != null ? DateTime.tryParse(updatedRaw) : null,
+      metadata: (json['metadata'] as Map<String, dynamic>?) ?? const {},
       tags: (json['tags'] as List<dynamic>?)
               ?.map((t) => t as String)
               .toList() ??
@@ -60,6 +63,7 @@ class Note {
         if (path != null) 'path': path,
         'createdAt': createdAt.toIso8601String(),
         if (updatedAt != null) 'updatedAt': updatedAt!.toIso8601String(),
+        if (metadata.isNotEmpty) 'metadata': metadata,
         'tags': tags,
         'links': links.map((l) => l.toJson()).toList(),
       };
@@ -70,6 +74,7 @@ class Note {
     String? path,
     DateTime? createdAt,
     DateTime? updatedAt,
+    Map<String, dynamic>? metadata,
     List<String>? tags,
     List<NoteLink>? links,
   }) {
@@ -79,6 +84,7 @@ class Note {
       path: path ?? this.path,
       createdAt: createdAt ?? this.createdAt,
       updatedAt: updatedAt ?? this.updatedAt,
+      metadata: metadata ?? this.metadata,
       tags: tags ?? this.tags,
       links: links ?? this.links,
     );

--- a/lib/core/services/graph_api_service.dart
+++ b/lib/core/services/graph_api_service.dart
@@ -39,8 +39,13 @@ class GraphApiService {
   // ---- Notes ----
 
   /// Query notes by tags, date range, etc.
+  ///
+  /// Pass [tags] with multiple values and [tagMatch] = `'any'` for OR queries
+  /// (e.g. show notes tagged `captured` OR `reader`).
   Future<List<Note>?> queryNotes({
     String? tag,
+    List<String>? tags,
+    String? tagMatch,
     String? excludeTag,
     String? dateFrom,
     String? dateTo,
@@ -48,7 +53,12 @@ class GraphApiService {
     int? limit,
   }) async {
     final params = <String, String>{};
-    if (tag != null) params['tag'] = tag;
+    if (tags != null && tags.isNotEmpty) {
+      params['tag'] = tags.join(',');
+      if (tagMatch != null) params['tag_match'] = tagMatch;
+    } else if (tag != null) {
+      params['tag'] = tag;
+    }
     if (excludeTag != null) params['exclude_tag'] = excludeTag;
     if (dateFrom != null) params['date_from'] = dateFrom;
     if (dateTo != null) params['date_to'] = dateTo;

--- a/lib/core/services/tag_service.dart
+++ b/lib/core/services/tag_service.dart
@@ -66,52 +66,6 @@ class TagService {
     }
   }
 
-  /// Get tags for a specific entity.
-  Future<List<String>> getEntityTags(String entityType, String entityId) async {
-    final uri = Uri.parse('$baseUrl/api/tags/$entityType/$entityId');
-    try {
-      final response =
-          await _client.get(uri, headers: _headers).timeout(_timeout);
-      if (response.statusCode < 200 || response.statusCode >= 300) {
-        return [];
-      }
-      final decoded = jsonDecode(response.body) as Map<String, dynamic>;
-      final List<dynamic> tags = decoded['tags'] as List<dynamic>? ?? [];
-      return tags.cast<String>();
-    } catch (e) {
-      debugPrint('[TagService] getEntityTags error: $e');
-      return [];
-    }
-  }
-
-  /// Add a tag to an entity.
-  Future<bool> addTag(String entityType, String entityId, String tag) async {
-    final uri = Uri.parse('$baseUrl/api/tags/$entityType/$entityId');
-    try {
-      final response = await _client
-          .post(uri,
-              headers: _headers, body: jsonEncode({'tag': tag}))
-          .timeout(_timeout);
-      return response.statusCode >= 200 && response.statusCode < 300;
-    } catch (e) {
-      debugPrint('[TagService] addTag error: $e');
-      return false;
-    }
-  }
-
-  /// Remove a tag from an entity.
-  Future<bool> removeTag(
-      String entityType, String entityId, String tag) async {
-    final uri = Uri.parse('$baseUrl/api/tags/$entityType/$entityId/$tag');
-    try {
-      final response =
-          await _client.delete(uri, headers: _headers).timeout(_timeout);
-      return response.statusCode >= 200 && response.statusCode < 300;
-    } catch (e) {
-      debugPrint('[TagService] removeTag error: $e');
-      return false;
-    }
-  }
 }
 
 /// Tag with usage count from the server.

--- a/lib/features/daily/journal/screens/journal_screen.dart
+++ b/lib/features/daily/journal/screens/journal_screen.dart
@@ -1130,18 +1130,17 @@ class _JournalScreenState extends ConsumerState<JournalScreen> with WidgetsBindi
     var allTags = <String>[];
     final isOnline = ref.read(isServerAvailableProvider);
     if (isOnline) {
+      final graphApi = ref.read(graphApiServiceProvider);
       final tagService = ref.read(tagServiceProvider);
       try {
         final results = await Future.wait([
-          tagService.getEntityTags('note', entry.id),
+          graphApi.getNote(entry.id),
           tagService.listTags(),
         ]);
-        final graphTags = results[0] as List<String>;
+        final note = results[0] as Note?;
         final tagInfos = results[1] as List<TagInfo>;
-        // Use graph tags as source of truth when online; keep metadata
-        // tags if graph has no record yet (entry not yet migrated).
-        if (graphTags.isNotEmpty) {
-          displayEntry = entry.copyWith(tags: graphTags);
+        if (note != null && note.tags.isNotEmpty) {
+          displayEntry = entry.copyWith(tags: note.tags);
         }
         allTags = tagInfos.map((t) => t.tag).toList();
       } catch (_) {
@@ -1186,15 +1185,17 @@ class _JournalScreenState extends ConsumerState<JournalScreen> with WidgetsBindi
             final oldTags = Set<String>.from(displayEntry.tags ?? []);
             final newTags = Set<String>.from(updatedEntry.tags ?? []);
             if (oldTags != newTags) {
-              final tagService = ref.read(tagServiceProvider);
-              for (final t in newTags.difference(oldTags)) {
-                tagService.addTag('note', updatedEntry.id, t).then((ok) {
-                  if (!ok) debugPrint('[JournalScreen] Tag sync failed: add "$t" to ${updatedEntry.id}');
+              final graphApi = ref.read(graphApiServiceProvider);
+              final toAdd = newTags.difference(oldTags).toList();
+              final toRemove = oldTags.difference(newTags).toList();
+              if (toAdd.isNotEmpty) {
+                graphApi.tagNote(updatedEntry.id, toAdd).then((n) {
+                  if (n == null) debugPrint('[JournalScreen] Tag sync failed: add $toAdd to ${updatedEntry.id}');
                 });
               }
-              for (final t in oldTags.difference(newTags)) {
-                tagService.removeTag('note', updatedEntry.id, t).then((ok) {
-                  if (!ok) debugPrint('[JournalScreen] Tag sync failed: remove "$t" from ${updatedEntry.id}');
+              if (toRemove.isNotEmpty) {
+                graphApi.untagNote(updatedEntry.id, toRemove).then((n) {
+                  if (n == null) debugPrint('[JournalScreen] Tag sync failed: remove $toRemove from ${updatedEntry.id}');
                 });
               }
             }

--- a/lib/features/daily/journal/services/daily_api_service.dart
+++ b/lib/features/daily/journal/services/daily_api_service.dart
@@ -134,7 +134,7 @@ class DailyApiService {
       final body = jsonEncode({
         'content': content,
         'tags': tags,
-        if (createdAt != null) 'createdAt': createdAt.toIso8601String(),
+        if (createdAt != null) 'created_at': createdAt.toIso8601String(),
       });
       final response = await _client
           .post(uri, headers: _headers, body: body)


### PR DESCRIPTION
## Summary
- **Fix `created_at` field name**: `DailyApiService.createNote` was sending `createdAt` (camelCase) but vault only accepts `created_at` (snake_case) — timestamps on typed notes were silently dropped
- **Add `metadata` field to Note model**: Parse and round-trip the vault's metadata object (source, duration, transcription info, etc.)
- **Support multi-tag OR queries**: `GraphApiService.queryNotes` now accepts `tags` (list) + `tagMatch` param for vault's `tag_match=any` support
- **Remove dead TagService methods**: `getEntityTags`, `addTag`, `removeTag` hit `/api/tags/{entityType}/{entityId}` routes that don't exist on the current vault
- **Migrate journal_screen tag ops**: Use `GraphApiService.tagNote`/`untagNote` (correct routes: `POST/DELETE /notes/:id/tags`)

Closes #48

## Test plan
- [ ] Create a typed note — verify it appears with correct timestamp (not server time)
- [ ] Open entry detail — tags load correctly from vault
- [ ] Edit tags on an entry — changes persist on reload
- [ ] Vault tab tag drill-down still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)