### PR TITLE
fix: use State.mounted instead of context.mounted (#29)

### DIFF
--- a/lib/features/daily/journal/screens/entry_detail_screen.dart
+++ b/lib/features/daily/journal/screens/entry_detail_screen.dart
@@ -253,7 +253,7 @@ class _EntryDetailScreenState extends ConsumerState<EntryDetailScreen> {
         icon: const Icon(Icons.arrow_back),
         onPressed: () async {
           final shouldPop = await _onWillPop();
-          if (shouldPop && context.mounted) {
+          if (shouldPop && mounted) {
             Navigator.of(context).pop();
           }
         },


### PR DESCRIPTION
## Summary
- One-line fix: `context.mounted` → `mounted` in entry_detail_screen.dart back button handler
- `State.mounted` is the correct check after an async gap in a StatefulWidget

Closes #29

## Test plan
- [ ] Back button on entry detail screen works after editing

🤖 Generated with [Claude Code](https://claude.com/claude-code)