### PR TITLE
chore: migrate sqlite3 to v3, remove sqlite3_flutter_libs (#31)

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -209,6 +209,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
+  code_assets:
+    dependency: transitive
+    description:
+      name: code_assets
+      sha256: "83ccdaa064c980b5596c35dd64a8d3ecc68620174ab9b90b6343b753aa721687"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   code_builder:
     dependency: transitive
     description:
@@ -626,6 +634,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
+  hooks:
+    dependency: transitive
+    description:
+      name: hooks
+      sha256: e79ed1e8e1929bc6ecb6ec85f0cb519c887aa5b423705ded0d0f2d9226def388
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.2"
   hotreloader:
     dependency: transitive
     description:
@@ -943,6 +959,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
+  native_toolchain_c:
+    dependency: transitive
+    description:
+      name: native_toolchain_c
+      sha256: "6ba77bb18063eebe9de401f5e6437e95e1438af0a87a3a39084fbd37c90df572"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.17.6"
   nordic_dfu:
     dependency: "direct main"
     description:
@@ -1456,18 +1480,10 @@ packages:
     dependency: "direct main"
     description:
       name: sqlite3
-      sha256: "3145bd74dcdb4fd6f5c6dda4d4e4490a8087d7f286a14dee5d37087290f0f8a2"
+      sha256: b3fe250b4ebd681a8ba20b12794c42b00c1375e5b51005568f0b8731265beb03
       url: "https://pub.dev"
     source: hosted
-    version: "2.9.4"
-  sqlite3_flutter_libs:
-    dependency: "direct main"
-    description:
-      name: sqlite3_flutter_libs
-      sha256: "1e800ebe7f85a80a66adacaa6febe4d5f4d8b75f244e9838a27cb2ffc7aec08d"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.5.41"
+    version: "3.3.0"
   stack_trace:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,8 +24,7 @@ dependencies:
   path_provider: ^2.0.0
   path: ^1.9.0
   shared_preferences: ^2.0.0
-  sqlite3: ^2.4.0
-  sqlite3_flutter_libs: '>=0.5.0 <0.7.0'
+  sqlite3: ^3.0.0
 
   # Deep Links
   app_links: ^6.3.2

--- a/test/note_local_cache_test.dart
+++ b/test/note_local_cache_test.dart
@@ -5,8 +5,8 @@
 /// or the Flutter test environment's native library setup.
 ///
 /// Run with: flutter test test/note_local_cache_test.dart
-/// Note: Requires sqlite3 native libraries. On macOS, these are available
-/// via sqlite3_flutter_libs. If tests hang on "loading", run via
+/// Note: Requires sqlite3 native libraries (bundled by sqlite3 ^3.0.0
+/// via Dart build hooks). If tests hang on "loading", run via
 /// integration_test/ instead.
 @TestOn('mac-os')
 library;


### PR DESCRIPTION
## Summary
- Upgrade `sqlite3` from `^2.4.0` to `^3.0.0` (v3 bundles native libs via Dart build hooks)
- Remove `sqlite3_flutter_libs` (now EOL — its job is handled by sqlite3 v3)
- Update test comment referencing the old package

Closes #31

## Test plan
- [ ] APK builds successfully (verified)
- [ ] App launches and local cache works (SQLite reads/writes)
- [ ] Voice recording + offline queue still functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)