### PR TITLE
fix: pending sync count updates live (#54)

### DIFF
--- a/lib/features/daily/journal/providers/journal_providers.dart
+++ b/lib/features/daily/journal/providers/journal_providers.dart
@@ -112,6 +112,8 @@ class _TodayJournalNotifier extends AutoDisposeAsyncNotifier<JournalDay> {
             final api = ref.read(dailyApiServiceProvider);
             final cache = await ref.read(noteLocalCacheProvider.future);
             await _flushPendingOps(api, cache);
+            // Refresh the journal and the pending banner to reflect flushed state.
+            ref.read(journalRefreshTriggerProvider.notifier).state++;
           } catch (e) {
             debugPrint('[_TodayJournalNotifier] Error flushing on reconnect: $e');
           }
@@ -313,7 +315,12 @@ String _nextDate(String date) => nextDate(date);
 // ============================================================================
 
 /// Count of notes pending sync (creates + edits + deletes).
+///
+/// Watches [journalRefreshTriggerProvider] so the banner updates immediately
+/// when a pending entry is inserted, flushed, or otherwise changes. Any code
+/// that mutates the cache should also bump the refresh trigger.
 final pendingSyncCountProvider = FutureProvider<int>((ref) async {
+  ref.watch(journalRefreshTriggerProvider);
   try {
     final cache = await ref.watch(noteLocalCacheProvider.future);
     return cache.getPendingCount();


### PR DESCRIPTION
## Audit note
I investigated #54 expecting to wire up a full offline create fallback — but most of it is already in place:

- \`_addEntryWithSafeQueue\` writes to cache as \`pending_create\` **before** trying the server POST. Content is never lost.
- \`_flushPendingOps\` handles creates, edits, and deletes. It runs on reconnect via \`ref.listen(periodicServerHealthProvider)\` and before every journal load.
- \`PendingSyncBanner\` shows the pending count with a Retry button wired to \`_retryPendingSync\`.
- The \`isPending\` flag on \`JournalEntry\` renders a \"Not uploaded yet\" chip with a cloud-upload icon on each card.
- Voice entries fall through to \`_appendEntryToCache\` which handles the offline case by saving with a local audio path, later flushed via \`ingestVoiceMemo\`.

The only real gap: **the banner count was stale** after pending mutations. \`pendingSyncCountProvider\` was a plain \`FutureProvider\` with no reactive triggers, so the banner kept showing an old number until the user manually retried.

## Summary
- \`pendingSyncCountProvider\` now watches \`journalRefreshTriggerProvider\` (which is already bumped after every cache mutation), so the banner updates live
- The reconnect listener now bumps the trigger after \`_flushPendingOps\` so the count reflects the post-flush state

7 lines changed. The rest of the feature was already working.

Closes #54

## Test plan
- [ ] Turn off wifi, type a note → banner appears immediately showing \"1 entry pending sync\"
- [ ] Type another → banner updates to \"2 entries pending sync\"
- [ ] Turn wifi back on → banner disappears when flush completes (no manual refresh needed)
- [ ] Offline voice memo → also shows in banner, clears on reconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)