### PR TITLE
fix: re-wire on-device transcription for local + auto-unreachable modes

### DIFF
--- a/lib/features/daily/journal/screens/journal_screen.dart
+++ b/lib/features/daily/journal/screens/journal_screen.dart
@@ -15,6 +15,7 @@ import 'package:parachute/core/providers/connectivity_provider.dart' show isServ
 import 'package:parachute/core/models/thing.dart';
 import 'package:parachute/core/services/note_local_cache.dart';
 import 'package:parachute/core/services/tag_service.dart' show TagInfo, tagServiceProvider;
+import '../../recorder/providers/post_hoc_transcription_provider.dart';
 import '../../recorder/providers/service_providers.dart';
 import '../models/entry_metadata.dart' show TranscriptionStatus;
 import '../models/journal_day.dart';
@@ -517,24 +518,52 @@ class _JournalScreenState extends ConsumerState<JournalScreen> with WidgetsBindi
     if (ingestResult != null && mounted) {
       debugPrint('[JournalScreen] Ingest succeeded: ${ingestResult.id}, content: ${ingestResult.content.length} chars');
 
-      // Clean up local audio — server has it now
-      try { await File(localAudioPath).delete(); } catch (_) {}
-
       // Force a full refresh from server — the note is there now.
       // Don't use _appendEntryToCache because the sync ingest takes long enough
       // that the journal state may have changed while we were waiting.
       ref.invalidate(selectedJournalProvider);
       ref.read(journalRefreshTriggerProvider.notifier).state++;
+
+      if (!useServerTranscription) {
+        // Server stored the audio with empty content (transcribe: false).
+        // Kick off on-device transcription via the post-hoc queue — it'll
+        // PATCH the entry with the transcript when complete and clean up
+        // the staged audio file. Fires for TranscriptionMode.local AND for
+        // auto-mode when the transcription service is unreachable.
+        // See parachute-daily#72.
+        debugPrint('[JournalScreen] Enqueuing on-device transcription for ${ingestResult.id}');
+        ref.read(postHocTranscriptionProvider.notifier).enqueue(
+          entryId: ingestResult.id,
+          audioPath: localAudioPath,
+          durationSeconds: duration,
+        );
+      } else {
+        // Server did the transcription atomically — safe to clean up now.
+        try { await File(localAudioPath).delete(); } catch (_) {}
+      }
       return;
     }
 
-    // Ingest failed — fall back to local flow
+    // Ingest failed — fall back to local flow. Thread through the mode flag
+    // so the fallback can also enqueue on-device transcription when needed.
     debugPrint('[JournalScreen] Ingest failed, falling back to local');
-    await _addVoiceEntryLocally(transcript, localAudioPath, duration, createdAt);
+    await _addVoiceEntryLocally(
+      transcript,
+      localAudioPath,
+      duration,
+      createdAt,
+      useServerTranscription: useServerTranscription,
+    );
   }
 
   /// Fallback local flow: upload audio asset, create entry, let on-device transcription handle it.
-  Future<void> _addVoiceEntryLocally(String transcript, String localAudioPath, int duration, DateTime createdAt) async {
+  Future<void> _addVoiceEntryLocally(
+    String transcript,
+    String localAudioPath,
+    int duration,
+    DateTime createdAt, {
+    required bool useServerTranscription,
+  }) async {
     final api = ref.read(dailyApiServiceProvider);
 
     // Try to upload audio to server first
@@ -564,10 +593,25 @@ class _JournalScreenState extends ConsumerState<JournalScreen> with WidgetsBindi
           audioPath: serverPath,
           durationSeconds: duration,
         );
-        try {
-          await File(localAudioPath).delete();
-        } catch (e) {
-          debugPrint('[JournalScreen] Failed to delete staged audio: $e');
+
+        if (!useServerTranscription) {
+          // Vault server is reachable enough for ingest fallback to upload
+          // and create the entry, but the user wants on-device transcription
+          // (local mode) or the transcription service is unreachable (auto
+          // falling back). Enqueue post-hoc — it owns the staged file lifecycle.
+          // See parachute-daily#72.
+          debugPrint('[JournalScreen] Enqueuing on-device transcription for ${entry.id} (fallback path)');
+          ref.read(postHocTranscriptionProvider.notifier).enqueue(
+            entryId: entry.id,
+            audioPath: localAudioPath,
+            durationSeconds: duration,
+          );
+        } else {
+          try {
+            await File(localAudioPath).delete();
+          } catch (e) {
+            debugPrint('[JournalScreen] Failed to delete staged audio: $e');
+          }
         }
       } else {
         // Upload succeeded but entry creation failed — queue with server path so audio
@@ -680,6 +724,11 @@ class _JournalScreenState extends ConsumerState<JournalScreen> with WidgetsBindi
     }
   }
 
+  // TODO(parachute-daily#78): this method and its `pendingTranscriptionEntryId`
+  // lookup appear to be orphaned wiring from the pre-ingest era (commit 17dcfec).
+  // `setPendingTranscription(entryId)` is never called with a non-null id
+  // anywhere in the codebase, so `entryId` is always null and this method
+  // is effectively dead. Investigate and remove.
   Future<void> _updatePendingTranscription(String transcript) async {
     final screenState = ref.read(journalScreenStateProvider);
     final entryId = screenState.pendingTranscriptionEntryId;

--- a/lib/features/daily/journal/widgets/journal_input_bar.dart
+++ b/lib/features/daily/journal/widgets/journal_input_bar.dart
@@ -7,10 +7,8 @@ import 'package:parachute/core/theme/design_tokens.dart';
 import 'package:parachute/core/providers/model_download_provider.dart';
 import '../../recorder/providers/service_providers.dart';
 import '../screens/entry_detail_screen.dart';
-import '../providers/journal_screen_state_provider.dart';
 import '../../recorder/providers/transcription_progress_provider.dart';
 import '../../recorder/providers/daily_recording_provider.dart';
-import '../../recorder/providers/post_hoc_transcription_provider.dart';
 import '../../recorder/widgets/recording_waveform.dart';
 import 'package:parachute/features/settings/screens/settings_screen.dart';
 
@@ -306,28 +304,16 @@ class _JournalInputBarState extends ConsumerState<JournalInputBar>
 
       debugPrint('[JournalInputBar] Daily recording stopped, audio at: $audioPath');
 
-      // Create entry immediately with empty transcript — "processing" state
-      // The entry appears in the list with a progress indicator
+      // Hand the recording off to the screen. JournalScreen's
+      // `_addVoiceEntry` handles ingest + on-device transcription enqueue
+      // (post-hoc) when the server isn't doing transcription itself. It
+      // has access to the entry id returned from ingest, which this widget
+      // does not. See parachute-daily#72 for the flow fix and #78 for the
+      // orphaned `pendingTranscriptionEntryId` wiring this block used to
+      // read from.
       if (widget.onVoiceRecorded != null) {
         await widget.onVoiceRecorded!('', audioPath, durationSeconds, createdAt);
       }
-
-      // Get the entry ID that was just created
-      final entryId = ref.read(journalScreenStateProvider).pendingTranscriptionEntryId;
-
-      if (entryId != null) {
-        // Enqueue post-hoc transcription — the provider handles everything:
-        // tracking, transcription, updating entry, failure/retry
-        ref.read(postHocTranscriptionProvider.notifier).enqueue(
-          entryId: entryId,
-          audioPath: audioPath,
-          durationSeconds: durationSeconds,
-        );
-        debugPrint('[JournalInputBar] Enqueued post-hoc transcription for $entryId');
-      } else {
-        debugPrint('[JournalInputBar] Warning: no entry ID after creation, skipping transcription');
-      }
-
     } catch (e) {
       debugPrint('[JournalInputBar] Failed to process Daily recording: $e');
       if (mounted) {

--- a/lib/features/daily/recorder/providers/post_hoc_transcription_provider.dart
+++ b/lib/features/daily/recorder/providers/post_hoc_transcription_provider.dart
@@ -287,6 +287,22 @@ class PostHocTranscriptionNotifier extends StateNotifier<PostHocTranscriptionSta
       _progressSubscription = null;
       _service?.dispose();
       _service = null;
+
+      // Clean up the staged audio file regardless of outcome. Safe because
+      // the server has its own copy (ingest or uploadAudio stored it before
+      // enqueue) — manual re-transcribe can pull the audio back from the
+      // server if the user wants to retry after a permanent failure. Only
+      // the crash-recovery path may leave files behind; `restartIncompleteJobs`
+      // already handles missing-file cases gracefully.
+      try {
+        final staged = File(audioPath);
+        if (await staged.exists()) {
+          await staged.delete();
+          debugPrint('[PostHocTranscription] Cleaned up staged audio: $audioPath');
+        }
+      } catch (e) {
+        debugPrint('[PostHocTranscription] Failed to clean up staged audio: $e');
+      }
     }
   }
 

--- a/lib/features/daily/recorder/providers/post_hoc_transcription_provider.dart
+++ b/lib/features/daily/recorder/providers/post_hoc_transcription_provider.dart
@@ -255,7 +255,10 @@ class PostHocTranscriptionNotifier extends StateNotifier<PostHocTranscriptionSta
     } catch (e) {
       debugPrint('[PostHocTranscription] ❌ Job failed for $entryId: $e');
 
-      // Mark job as failed (keeps the file for retry)
+      // Mark job as failed — staged file will be cleaned up in the finally
+      // block below. The server still has its own copy of the audio (stored
+      // at ingest/uploadAudio time before this job was enqueued), so manual
+      // re-transcribe can pull it back if the user wants to retry.
       await _tracker.failJob(entryId);
 
       // Update server-side status


### PR DESCRIPTION
Closes #72. Filed #78 for the orphaned wiring this PR routes around.

## Summary

Voice memos saved in `TranscriptionMode.local` (and in `auto` mode when the transcription service is unreachable) were silently landing as empty notes because the post-hoc on-device transcription queue was never invoked from the save path.

## Root cause

Investigation revealed the bug is subtler than the issue body suggested. The on-device transcription infrastructure is alive and working (`PostHocTranscriptionNotifier`, `TranscriptionServiceAdapter`, `RecordingPostProcessingService`) — it's used successfully by the manual re-transcribe button's `_retranscribeLocally` today.

The bug is a **dead-code wiring regression** in \`journal_input_bar.dart:315-329\`:

\`\`\`dart
final entryId = ref.read(journalScreenStateProvider).pendingTranscriptionEntryId;

if (entryId != null) {
  ref.read(postHocTranscriptionProvider.notifier).enqueue(...);
} else {
  debugPrint('[JournalInputBar] Warning: no entry ID after creation, skipping transcription');
}
\`\`\`

Every reference to \`pendingTranscriptionEntryId\` in the codebase: **read** in two places, **cleared** in one place, and **never set** to a non-null value anywhere. So \`entryId\` is always null and the enqueue branch is dead. Apparent regression from commit \`17dcfec\` ("feat: switch voice memo flow to POST /api/ingest"), which assumed server-side transcription and left the post-hoc wiring orphaned.

The bug is also broader than \`TranscriptionMode.local\`: auto mode with an unreachable transcription service falls into the same \`transcribe: false\` path and also produces empty notes.

## Fix

- **\`journal_screen._addVoiceEntry\`**: when ingest succeeds AND \`useServerTranscription\` is false, directly call \`postHocTranscriptionProvider.notifier.enqueue\` with \`ingestResult.id\`. Skip the local-file delete in that branch — the post-hoc pipeline now owns the staged audio file lifecycle.
- **\`journal_screen._addVoiceEntryLocally\`**: thread \`useServerTranscription\` through as a required named parameter. Enqueue post-hoc after successful \`createEntry\` for the same cases, and skip the file delete symmetrically.
- **\`journal_input_bar._stopDailyRecording\`**: delete the dead-code enqueue block entirely. The screen now owns the enqueue and has access to the real entry id from the ingest response.
- **\`post_hoc_transcription_provider._processJob\`**: delete the staged audio file in the \`finally\` block, covering both success and permanent-failure paths. Safe because the server has its own copy (ingest/uploadAudio stored it before enqueue). Manual re-transcribe can still pull the audio back if the user wants to retry after a permanent failure. \`restartIncompleteJobs\` already handles missing-file cases gracefully, so crash recovery still works.

## Mode matrix after this change

| mode                    | reachability    | path                                     |
| ----------------------- | --------------- | ---------------------------------------- |
| \`server\`                | any             | server transcribes atomically            |
| \`auto\`, reachable       | —               | server transcribes atomically            |
| \`auto\`, unreachable     | —               | ingest empty → post-hoc (**NEW**)        |
| \`local\`                 | any             | ingest empty → post-hoc (**NEW**)        |
| any, vault server down  | offline         | local queue (no transcription yet)       |

The truly-offline branch of \`_addVoiceEntryLocally\` still queues with empty content — no post-hoc because we have no server entry id to update. **Not a regression** (already broken on main), out of scope for #72.

## Test plan

- [ ] **Auto mode with server reachable** (happy path): record a voice memo. Expect entry to appear immediately with transcript populated atomically from the server. Should be unchanged.
- [ ] **Local mode**: flip Settings → Transcription to Local. Record a voice memo. Expect entry to appear in the list with the "processing" spinner, then have its content populated shortly after by on-device transcription. Staged audio file under the app's temp/staging directory should be gone after completion.
- [ ] **Auto mode with transcription service unreachable**: record a voice memo with the external transcription service offline. Expect the same behavior as local mode — entry appears, spins, then populates from on-device.
- [ ] **Server mode**: unchanged behavior — server transcribes, no on-device path.
- [ ] **Manual re-transcribe** button: still works for all modes. Should not have regressed.
- [ ] **Permanent failure**: trigger a transcription failure (e.g. corrupt audio or broken model) in local mode. Expect the entry to be marked failed on the server and the staged audio file to be removed (server still has its own copy, so the user can manually re-transcribe).
- [ ] **\`flutter analyze\`** on the three changed files → no new issues introduced. (Two pre-existing warnings on journal_screen.dart remain, unrelated to this PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)