### PR TITLE
chore: remove orphaned live-transcription wiring

### DIFF
--- a/lib/features/daily/journal/providers/journal_screen_state_provider.dart
+++ b/lib/features/daily/journal/providers/journal_screen_state_provider.dart
@@ -20,16 +20,12 @@ class JournalScreenState {
   /// Enhancement status message per entry
   final Map<String, String> enhancementStatus;
 
-  /// Entry pending transcription (for streaming audio)
-  final String? pendingTranscriptionEntryId;
-
   const JournalScreenState({
     this.transcribingEntryIds = const {},
     this.transcriptionProgress = const {},
     this.enhancingEntryIds = const {},
     this.enhancementProgress = const {},
     this.enhancementStatus = const {},
-    this.pendingTranscriptionEntryId,
   });
 
   JournalScreenState copyWith({
@@ -38,8 +34,6 @@ class JournalScreenState {
     Set<String>? enhancingEntryIds,
     Map<String, double?>? enhancementProgress,
     Map<String, String>? enhancementStatus,
-    String? pendingTranscriptionEntryId,
-    bool clearPendingTranscription = false,
   }) {
     return JournalScreenState(
       transcribingEntryIds: transcribingEntryIds ?? this.transcribingEntryIds,
@@ -47,9 +41,6 @@ class JournalScreenState {
       enhancingEntryIds: enhancingEntryIds ?? this.enhancingEntryIds,
       enhancementProgress: enhancementProgress ?? this.enhancementProgress,
       enhancementStatus: enhancementStatus ?? this.enhancementStatus,
-      pendingTranscriptionEntryId: clearPendingTranscription
-          ? null
-          : (pendingTranscriptionEntryId ?? this.pendingTranscriptionEntryId),
     );
   }
 }
@@ -65,14 +56,6 @@ class JournalScreenStateNotifier extends StateNotifier<JournalScreenState> {
   void dispose() {
     _progressDebounceTimer?.cancel();
     super.dispose();
-  }
-
-  /// Set pending transcription entry ID
-  void setPendingTranscription(String? entryId) {
-    state = state.copyWith(
-      pendingTranscriptionEntryId: entryId,
-      clearPendingTranscription: entryId == null,
-    );
   }
 
   /// Start transcription for an entry

--- a/lib/features/daily/journal/screens/journal_screen.dart
+++ b/lib/features/daily/journal/screens/journal_screen.dart
@@ -175,7 +175,6 @@ class _JournalScreenState extends ConsumerState<JournalScreen> with WidgetsBindi
                 onTextSubmitted: (text) => _addTextEntry(text),
                 onVoiceRecorded: (transcript, audioPath, duration, createdAt) =>
                     _addVoiceEntry(transcript, audioPath, duration, createdAt),
-                onTranscriptReady: (transcript) => _updatePendingTranscription(transcript),
                 onComposeSubmitted: (title, content) =>
                     _addComposeEntry(title, content),
               ),
@@ -317,19 +316,6 @@ class _JournalScreenState extends ConsumerState<JournalScreen> with WidgetsBindi
         }
       });
     }
-  }
-
-  // ========== Error Feedback ==========
-
-  void _showErrorSnackbar(String message) {
-    if (!mounted) return;
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text(message),
-        backgroundColor: BrandColors.error,
-        duration: const Duration(seconds: 3),
-      ),
-    );
   }
 
   // ========== Entry CRUD Operations ==========
@@ -721,58 +707,6 @@ class _JournalScreenState extends ConsumerState<JournalScreen> with WidgetsBindi
       if (entry.isServerProcessing) {
         _startPollingEntry(entry.id);
       }
-    }
-  }
-
-  // TODO(parachute-daily#78): this method and its `pendingTranscriptionEntryId`
-  // lookup appear to be orphaned wiring from the pre-ingest era (commit 17dcfec).
-  // `setPendingTranscription(entryId)` is never called with a non-null id
-  // anywhere in the codebase, so `entryId` is always null and this method
-  // is effectively dead. Investigate and remove.
-  Future<void> _updatePendingTranscription(String transcript) async {
-    final screenState = ref.read(journalScreenStateProvider);
-    final entryId = screenState.pendingTranscriptionEntryId;
-
-    if (entryId == null) {
-      debugPrint('[JournalScreen] No pending entry to update');
-      return;
-    }
-
-    ref.read(journalScreenStateProvider.notifier).setPendingTranscription(null);
-    debugPrint('[JournalScreen] Updating entry $entryId with transcript...');
-
-    try {
-      final api = ref.read(dailyApiServiceProvider);
-      final existingEntry = _cachedJournal?.getEntry(entryId);
-
-      final serverUpdated = await api.updateEntry(entryId, content: transcript);
-      if (serverUpdated == null) throw Exception('Server unreachable');
-      debugPrint('[JournalScreen] Transcription update complete');
-
-      JournalEntry? updatedEntry;
-      if (existingEntry != null && _cachedJournal != null) {
-        updatedEntry = existingEntry.copyWith(content: transcript);
-        setState(() {
-          _cachedJournal = _cachedJournal!.updateEntry(updatedEntry!);
-        });
-      }
-
-      ref.invalidate(selectedJournalProvider);
-
-      // Auto-enhance if enabled
-      if (transcript.isNotEmpty) {
-        final autoEnhance = await ref.read(autoEnhanceProvider.future);
-        if (autoEnhance) {
-          debugPrint('[JournalScreen] Auto-enhancing transcription...');
-          await Future.delayed(const Duration(milliseconds: 100));
-          if (mounted && updatedEntry != null) {
-            _handleEnhance(updatedEntry);
-          }
-        }
-      }
-    } catch (e, st) {
-      debugPrint('[JournalScreen] Error updating transcription: $e\n$st');
-      _showErrorSnackbar('Voice note saved, but transcript update failed');
     }
   }
 

--- a/lib/features/daily/journal/widgets/journal_content_view.dart
+++ b/lib/features/daily/journal/widgets/journal_content_view.dart
@@ -93,9 +93,7 @@ class JournalContentView extends ConsumerWidget {
           key: ValueKey(entry.id),
           entry: entry,
           audioPath: journal.getAudioPath(entry.id),
-          // Show transcribing for both manual transcribe and background transcription
-          isTranscribing: screenState.transcribingEntryIds.contains(entry.id) ||
-              screenState.pendingTranscriptionEntryId == entry.id,
+          isTranscribing: screenState.transcribingEntryIds.contains(entry.id),
           transcriptionProgress: screenState.transcriptionProgress[entry.id] ?? 0.0,
           isEnhancing: screenState.enhancingEntryIds.contains(entry.id),
           enhancementProgress: screenState.enhancementProgress[entry.id],

--- a/lib/features/daily/journal/widgets/journal_entry_list.dart
+++ b/lib/features/daily/journal/widgets/journal_entry_list.dart
@@ -83,9 +83,7 @@ class JournalEntryList extends ConsumerWidget {
                         audioPath: journal.getAudioPath(entry.id),
                         isEditing: isEditing,
                         saveState: isEditing ? currentSaveState : EntrySaveState.saved,
-                        // Show transcribing for both manual transcribe and background transcription
-                        isTranscribing: screenState.transcribingEntryIds.contains(entry.id) ||
-                            screenState.pendingTranscriptionEntryId == entry.id,
+                        isTranscribing: screenState.transcribingEntryIds.contains(entry.id),
                         transcriptionProgress: screenState.transcriptionProgress[entry.id] ?? 0.0,
                         isEnhancing: screenState.enhancingEntryIds.contains(entry.id),
                         enhancementProgress: screenState.enhancementProgress[entry.id],

--- a/lib/features/daily/journal/widgets/journal_input_bar.dart
+++ b/lib/features/daily/journal/widgets/journal_input_bar.dart
@@ -20,8 +20,6 @@ class JournalInputBar extends ConsumerStatefulWidget {
   final Future<void> Function(String text) onTextSubmitted;
   final Future<void> Function(String transcript, String audioPath, int duration, DateTime createdAt)?
       onVoiceRecorded;
-  /// Called when background transcription completes - allows updating the entry
-  final Future<void> Function(String transcript)? onTranscriptReady;
   /// Called when the full-screen compose screen saves an entry (title + content)
   final Future<void> Function(String title, String content)? onComposeSubmitted;
 
@@ -29,7 +27,6 @@ class JournalInputBar extends ConsumerStatefulWidget {
     super.key,
     required this.onTextSubmitted,
     this.onVoiceRecorded,
-    this.onTranscriptReady,
     this.onComposeSubmitted,
   });
 
@@ -308,9 +305,7 @@ class _JournalInputBarState extends ConsumerState<JournalInputBar>
       // `_addVoiceEntry` handles ingest + on-device transcription enqueue
       // (post-hoc) when the server isn't doing transcription itself. It
       // has access to the entry id returned from ingest, which this widget
-      // does not. See parachute-daily#72 for the flow fix and #78 for the
-      // orphaned `pendingTranscriptionEntryId` wiring this block used to
-      // read from.
+      // does not.
       if (widget.onVoiceRecorded != null) {
         await widget.onVoiceRecorded!('', audioPath, durationSeconds, createdAt);
       }

--- a/lib/features/daily/recorder/providers/post_hoc_transcription_provider.dart
+++ b/lib/features/daily/recorder/providers/post_hoc_transcription_provider.dart
@@ -92,28 +92,6 @@ class PostHocTranscriptionNotifier extends StateNotifier<PostHocTranscriptionSta
     _processQueue();
   }
 
-  /// Retry a failed transcription
-  Future<void> retry(String entryId, String audioPath, int durationSeconds) async {
-    debugPrint('[PostHocTranscription] Retrying job for entry $entryId');
-
-    // Transition server status back to processing
-    try {
-      final api = _ref.read(dailyApiServiceProvider);
-      await api.updateEntry(
-        entryId,
-        metadata: {'transcription_status': 'processing'},
-      );
-    } catch (e) {
-      debugPrint('[PostHocTranscription] Failed to update server status for retry: $e');
-    }
-
-    await enqueue(
-      entryId: entryId,
-      audioPath: audioPath,
-      durationSeconds: durationSeconds,
-    );
-  }
-
   /// Check for incomplete jobs on app startup and restart them
   Future<void> restartIncompleteJobs() async {
     final incompleteJobs = await _tracker.getIncompleteJobs();


### PR DESCRIPTION
## Summary
- Deletes dead-code wiring from the pre-ingest era, surfaced during parachute-daily#72's investigation
- Removes `pendingTranscriptionEntryId` field + setter (never set to non-null anywhere)
- Removes `_updatePendingTranscription` (always early-returned on null entryId)
- Removes `JournalInputBar.onTranscriptReady` callback (only wired the above)
- Removes two `||` guards in entry-list widgets that always evaluated false
- Removes `PostHocTranscriptionNotifier.retry()` (no callers)
- Removes `_showErrorSnackbar` (only caller was `_updatePendingTranscription`)

Net: 117 deletions, 3 insertions across 6 files. Purely mechanical — no behavior change.

Closes parachute-daily#78

## Test plan
- [x] `flutter analyze` on changed files — no new warnings (2 pre-existing warnings on main unchanged)
- [ ] Verify voice recording flow still enqueues post-hoc transcription for local/offline modes (regression check from #72/#79)
- [ ] Verify the transcribing spinner still shows during post-hoc transcription (driven by `transcribingEntryIds`, which is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)