### PR TITLE
fix: use .m4a extension for iOS voice memo recordings

### DIFF
--- a/lib/core/services/file_system_service.dart
+++ b/lib/core/services/file_system_service.dart
@@ -584,8 +584,9 @@ class FileSystemService {
   ///
   /// [extension] controls the file suffix. Defaults to `wav` for legacy
   /// callers (e.g. Omi capture service which writes PCM WAV bytes). The
-  /// voice memo recorder uses `ogg` because `AudioEncoder.opus` from the
-  /// `record` package produces an OGG container with Opus audio.
+  /// voice memo recorder passes `ogg` on Android and `m4a` on iOS/macOS
+  /// — the `record` package's AVFoundation backends produce an M4A
+  /// container even with `AudioEncoder.opus`. See parachute-daily#68.
   Future<String> getRecordingTempPath({String extension = 'wav'}) async {
     final tempPath = await getTempAudioPath();
     final timestamp = DateTime.now().millisecondsSinceEpoch;

--- a/lib/core/services/transcription/audio_service.dart
+++ b/lib/core/services/transcription/audio_service.dart
@@ -164,15 +164,16 @@ class AudioService {
   Future<String> _getRecordingPath(String recordingId) async {
     try {
       // Temp folder for recording-in-progress Opus files. Extension is
-      // platform-dependent because the `record` package's iOS backend
-      // (`record_ios`) falls `AudioEncoder.opus` through to `AVFileType.m4a`,
-      // producing an M4A container with Opus audio — not a real OGG file.
-      // Android's backend uses `MediaMuxer.OutputFormat.MUXER_OUTPUT_OGG`
-      // and does produce a real OGG container. We name each file after its
-      // actual container so downstream mime-inference (audio/mp4 vs audio/ogg)
-      // matches reality. See parachute-daily#68 and parachute-vault#45.
+      // platform-dependent because the `record` package's AVFoundation-based
+      // backends (`record_ios`, `record_macos`) fall `AudioEncoder.opus`
+      // through to `AVFileType.m4a`, producing an M4A container with Opus
+      // audio — not a real OGG file. Android's backend uses
+      // `MediaMuxer.OutputFormat.MUXER_OUTPUT_OGG` and does produce a real
+      // OGG container. We name each file after its actual container so
+      // downstream mime-inference (audio/mp4 vs audio/ogg) matches reality.
+      // See parachute-daily#68 and parachute-vault#45.
       final fileSystem = FileSystemService.daily();
-      final extension = Platform.isIOS ? 'm4a' : 'ogg';
+      final extension = (Platform.isIOS || Platform.isMacOS) ? 'm4a' : 'ogg';
       final path = await fileSystem.getRecordingTempPath(extension: extension);
       debugPrint('Generated temp recording path: $path');
       return path;
@@ -234,10 +235,11 @@ class AudioService {
       await WakelockPlus.enable();
       debugPrint('Wakelock enabled');
 
-      // Start recording with OGG Opus format.
-      // Server-side storage was unified to Opus in parachute-vault#45;
-      // recording directly as Opus on-device matches that format so no
-      // transcoding is needed on upload.
+      // Start recording with Opus audio. Container is OGG on Android and
+      // M4A on iOS/macOS — the `record` package's AVFoundation backends
+      // don't support OGG. Server-side storage was unified to Opus in
+      // parachute-vault#45; on-device Opus encoding matches that format
+      // so no transcoding is needed on upload. See parachute-daily#68.
       debugPrint('Starting recorder...');
       await _recorder.start(
         const RecordConfig(

--- a/lib/core/services/transcription/audio_service.dart
+++ b/lib/core/services/transcription/audio_service.dart
@@ -163,12 +163,17 @@ class AudioService {
 
   Future<String> _getRecordingPath(String recordingId) async {
     try {
-      // Use temp folder for recording-in-progress OGG Opus files.
-      // AudioEncoder.opus in the `record` package produces an OGG container
-      // with Opus audio, so we use the `.ogg` extension to match the
-      // server-side Opus-migrated assets (see parachute-vault#45).
+      // Temp folder for recording-in-progress Opus files. Extension is
+      // platform-dependent because the `record` package's iOS backend
+      // (`record_ios`) falls `AudioEncoder.opus` through to `AVFileType.m4a`,
+      // producing an M4A container with Opus audio — not a real OGG file.
+      // Android's backend uses `MediaMuxer.OutputFormat.MUXER_OUTPUT_OGG`
+      // and does produce a real OGG container. We name each file after its
+      // actual container so downstream mime-inference (audio/mp4 vs audio/ogg)
+      // matches reality. See parachute-daily#68 and parachute-vault#45.
       final fileSystem = FileSystemService.daily();
-      final path = await fileSystem.getRecordingTempPath(extension: 'ogg');
+      final extension = Platform.isIOS ? 'm4a' : 'ogg';
+      final path = await fileSystem.getRecordingTempPath(extension: extension);
       debugPrint('Generated temp recording path: $path');
       return path;
     } catch (e) {


### PR DESCRIPTION
## Summary
- Fixes parachute-daily#68: iOS voice memos were being written to files named `.ogg` but the actual container produced by `record_ios`'s `AudioEncoder.opus` → `AVFileType.m4a` fallback was M4A. The bytes never matched the extension on iOS.
- Branches on `Platform.isIOS` in `AudioService._getRecordingPath` to pick `'m4a'` on iOS and `'ogg'` on Android. Android's `record` backend uses `MediaMuxer.OutputFormat.MUXER_OUTPUT_OGG` and does produce a true OGG container.
- No other code changes needed: the mime-inference switches in `daily_api_service.dart:334-341` and `journal_providers.dart:281-288` already map `.m4a`/`.mp4` → `audio/mp4`, so the fix propagates through to the attachment metadata automatically.

This is Option 1 from the issue's remediation list ("platform branch on extension"). Option 2 (switch iOS to AAC) would lose the Opus unification goal. Options 3/4 (custom recorder / upstream fix) are overkill for a naming bug.

Closes parachute-daily#68

## Test plan
- [x] `flutter analyze` — no issues on the changed file
- [ ] Android: record a voice memo → file is still `.ogg`, attachment mime is still `audio/ogg` (regression check)
- [ ] iOS: record a voice memo → file is now `.m4a`, attachment mime resolves to `audio/mp4`, playback + transcription both work end-to-end (scribe's ffmpeg already handled the M4A bytes before, should continue to)
- [ ] Existing `.ogg`-named iOS files from before this PR still play — `just_audio` is format-agnostic so the historical files continue to work via content sniffing

🤖 Generated with [Claude Code](https://claude.com/claude-code)