### PR TITLE
fix: tag mutations — persist changes, surface errors, wire autocomplete

### DIFF
--- a/lib/core/screens/note_detail_screen.dart
+++ b/lib/core/screens/note_detail_screen.dart
@@ -6,6 +6,7 @@ import 'package:parachute/core/models/thing.dart';
 import 'package:parachute/core/widgets/note_audio_player.dart';
 import 'package:parachute/core/widgets/tag_input.dart';
 import 'package:parachute/features/daily/journal/providers/journal_providers.dart';
+import 'package:parachute/features/vault/providers/vault_providers.dart';
 
 /// Detail screen for viewing/editing a Note.
 ///
@@ -85,8 +86,19 @@ class _NoteDetailScreenState extends ConsumerState<NoteDetailScreen> {
     // Sync tags: add new, remove old
     final newTags = _tags.where((t) => !_originalTags.contains(t)).toList();
     final removedTags = _originalTags.where((t) => !_tags.contains(t)).toList();
-    if (newTags.isNotEmpty) await api.tagNote(widget.note.id, newTags);
-    if (removedTags.isNotEmpty) await api.untagNote(widget.note.id, removedTags);
+    bool tagFailed = false;
+    if (newTags.isNotEmpty) {
+      final result = await api.tagNote(widget.note.id, newTags);
+      if (result == null) tagFailed = true;
+    }
+    if (removedTags.isNotEmpty) {
+      final result = await api.untagNote(widget.note.id, removedTags);
+      if (result == null) tagFailed = true;
+    }
+
+    if (newTags.isNotEmpty || removedTags.isNotEmpty) {
+      ref.invalidate(vaultTagsProvider);
+    }
 
     _originalTitle = _titleController.text;
     _originalContent = _contentController.text;
@@ -96,6 +108,12 @@ class _NoteDetailScreenState extends ConsumerState<NoteDetailScreen> {
       _saving = false;
       _isEditing = false;
     });
+
+    if (tagFailed && mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Some tag changes may not have saved')),
+      );
+    }
 
     widget.onChanged?.call();
   }
@@ -215,7 +233,7 @@ class _NoteDetailScreenState extends ConsumerState<NoteDetailScreen> {
           onChanged: (_) => setState(() {}),
         ),
         const Divider(),
-        TagInput(
+        _TagInputWithSuggestions(
           tags: _tags,
           onChanged: (tags) => setState(() => _tags = tags),
         ),
@@ -247,5 +265,27 @@ class _NoteDetailScreenState extends ConsumerState<NoteDetailScreen> {
   String _fmtDate(DateTime dt) {
     final months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
     return '${months[dt.month - 1]} ${dt.day}, ${dt.year}';
+  }
+}
+
+/// TagInput wrapper that fetches vault tags for autocomplete suggestions.
+class _TagInputWithSuggestions extends ConsumerWidget {
+  final List<String> tags;
+  final void Function(List<String>) onChanged;
+
+  const _TagInputWithSuggestions({required this.tags, required this.onChanged});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final tagsAsync = ref.watch(vaultTagsProvider);
+    final suggestions = tagsAsync.valueOrNull
+            ?.map((t) => t.tag)
+            .toList() ??
+        [];
+    return TagInput(
+      tags: tags,
+      onChanged: onChanged,
+      suggestions: suggestions,
+    );
   }
 }

--- a/lib/core/widgets/tag_input.dart
+++ b/lib/core/widgets/tag_input.dart
@@ -48,11 +48,11 @@ class _TagInputState extends State<TagInput> {
   void _addTag(String raw) {
     if (raw.isEmpty) return;
     final tag = raw.toLowerCase().replaceAll(' ', '-');
-    // Validate: alphanumeric + hyphens, max 48 chars
-    if (!RegExp(r'^[a-z0-9](?:[a-z0-9\-]{0,46}[a-z0-9])?$').hasMatch(tag)) {
+    // Validate: alphanumeric + hyphens + slashes (for hierarchy), max 48 chars
+    if (!RegExp(r'^[a-z0-9](?:[a-z0-9\-/]{0,46}[a-z0-9])?$').hasMatch(tag)) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(
-          content: Text('Tags must be lowercase letters, numbers, and hyphens'),
+          content: Text('Tags must be lowercase letters, numbers, hyphens, and slashes'),
           duration: Duration(seconds: 2),
         ),
       );

--- a/lib/features/daily/journal/screens/journal_screen.dart
+++ b/lib/features/daily/journal/screens/journal_screen.dart
@@ -15,6 +15,7 @@ import 'package:parachute/core/providers/connectivity_provider.dart' show isServ
 import 'package:parachute/core/models/thing.dart';
 import 'package:parachute/core/services/note_local_cache.dart';
 import 'package:parachute/core/services/tag_service.dart' show TagInfo, tagServiceProvider;
+import 'package:parachute/features/vault/providers/vault_providers.dart';
 import '../../recorder/providers/post_hoc_transcription_provider.dart';
 import '../../recorder/providers/service_providers.dart';
 import '../models/entry_metadata.dart' show TranscriptionStatus;
@@ -1181,8 +1182,7 @@ class _JournalScreenState extends ConsumerState<JournalScreen> with WidgetsBindi
               cache.markForEdit(updatedEntry.id, content: updatedEntry.content);
             }
 
-            // Sync tag changes to graph — best-effort alongside metadata.
-            // Metadata is the durable path; backend migration catches gaps.
+            // Sync tag changes to graph.
             if (!mounted) return;
             final oldTags = Set<String>.from(displayEntry.tags ?? []);
             final newTags = Set<String>.from(updatedEntry.tags ?? []);
@@ -1190,15 +1190,20 @@ class _JournalScreenState extends ConsumerState<JournalScreen> with WidgetsBindi
               final graphApi = ref.read(graphApiServiceProvider);
               final toAdd = newTags.difference(oldTags).toList();
               final toRemove = oldTags.difference(newTags).toList();
+              bool tagFailed = false;
               if (toAdd.isNotEmpty) {
-                graphApi.tagNote(updatedEntry.id, toAdd).then((n) {
-                  if (n == null) debugPrint('[JournalScreen] Tag sync failed: add $toAdd to ${updatedEntry.id}');
-                });
+                final result = await graphApi.tagNote(updatedEntry.id, toAdd);
+                if (result == null) tagFailed = true;
               }
               if (toRemove.isNotEmpty) {
-                graphApi.untagNote(updatedEntry.id, toRemove).then((n) {
-                  if (n == null) debugPrint('[JournalScreen] Tag sync failed: remove $toRemove from ${updatedEntry.id}');
-                });
+                final result = await graphApi.untagNote(updatedEntry.id, toRemove);
+                if (result == null) tagFailed = true;
+              }
+              ref.invalidate(vaultTagsProvider);
+              if (tagFailed && mounted) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(content: Text('Some tag changes may not have saved')),
+                );
               }
             }
 

--- a/lib/features/digest/screens/digest_screen.dart
+++ b/lib/features/digest/screens/digest_screen.dart
@@ -4,6 +4,7 @@ import 'package:parachute/core/models/thing.dart';
 import 'package:parachute/core/screens/note_detail_screen.dart';
 import 'package:parachute/core/theme/design_tokens.dart';
 import 'package:parachute/features/daily/journal/providers/journal_providers.dart';
+import 'package:parachute/features/vault/providers/vault_providers.dart';
 import '../providers/digest_providers.dart';
 
 /// Reader tab — inbox of content to process.
@@ -261,7 +262,7 @@ class _DigestCard extends ConsumerWidget {
       confirmDismiss: (direction) async {
         if (direction == DismissDirection.startToEnd) {
           // Pin/unpin — toggle in place, don't dismiss.
-          await _togglePin(ref);
+          await _togglePin(context, ref);
           return false;
         }
         // Archive/unarchive — dismiss and show undo.
@@ -405,7 +406,7 @@ class _DigestCard extends ConsumerWidget {
         onSelected: (value) async {
           switch (value) {
             case 'pin':
-              await _togglePin(ref);
+              await _togglePin(context, ref);
             case 'archive':
               await _toggleArchive(context, ref);
           }
@@ -472,13 +473,18 @@ class _DigestCard extends ConsumerWidget {
     ];
   }
 
-  Future<void> _togglePin(WidgetRef ref) async {
+  Future<void> _togglePin(BuildContext context, WidgetRef ref) async {
     final api = ref.read(graphApiServiceProvider);
-    if (note.isPinned) {
-      await api.untagNote(note.id, ['pinned']);
-    } else {
-      await api.tagNote(note.id, ['pinned']);
+    final result = note.isPinned
+        ? await api.untagNote(note.id, ['pinned'])
+        : await api.tagNote(note.id, ['pinned']);
+    if (result == null && context.mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Failed to update pin — check connection')),
+      );
+      return;
     }
+    ref.invalidate(vaultTagsProvider);
     onChanged();
   }
 
@@ -487,11 +493,16 @@ class _DigestCard extends ConsumerWidget {
     final api = ref.read(graphApiServiceProvider);
     final wasArchived = note.isArchived;
 
-    if (wasArchived) {
-      await api.untagNote(note.id, ['archived']);
-    } else {
-      await api.tagNote(note.id, ['archived']);
+    final result = wasArchived
+        ? await api.untagNote(note.id, ['archived'])
+        : await api.tagNote(note.id, ['archived']);
+    if (result == null && context.mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Failed to update archive — check connection')),
+      );
+      return;
     }
+    ref.invalidate(vaultTagsProvider);
     onChanged();
 
     if (!context.mounted) return;
@@ -505,10 +516,11 @@ class _DigestCard extends ConsumerWidget {
         action: SnackBarAction(
           label: 'Undo',
           onPressed: () async {
-            if (wasArchived) {
-              await api.tagNote(note.id, ['archived']);
-            } else {
-              await api.untagNote(note.id, ['archived']);
+            final undoResult = wasArchived
+                ? await api.tagNote(note.id, ['archived'])
+                : await api.untagNote(note.id, ['archived']);
+            if (undoResult != null) {
+              ref.invalidate(vaultTagsProvider);
             }
             onChanged();
           },


### PR DESCRIPTION
## Summary

Phase 1 of #57 (tag UI revamp). Fixes the core bugs and wires up missing plumbing:

- **Fix TagInput regex** to allow `/` for hierarchical tags (`reader/summary`)
- **Error handling on all tag mutation paths** — snackbar on failure instead of silent `debugPrint`
- **Invalidate `vaultTagsProvider`** after tag mutations so Vault tab tag counts stay in sync
- **Wire server tags into TagInput** as autocomplete suggestions via `vaultTagsProvider`
- **Convert journal tag sync** from fire-and-forget `.then()` to awaited with error feedback

4 files changed, 86 insertions, 29 deletions.

## Test plan

- [ ] Open a Reader note → pin/unpin → confirm it persists after navigating away and back
- [ ] Archive a Reader note → confirm it disappears from Reader → undo → confirm it reappears
- [ ] Edit tags on a note in NoteDetailScreen → save → confirm tags persist
- [ ] Type a hierarchical tag like `reader/summary` in TagInput → confirm it's accepted
- [ ] Edit tags on NoteDetailScreen → confirm autocomplete suggestions appear from vault tags
- [ ] Edit tags on a journal entry → confirm changes persist
- [ ] Disconnect server → try tag mutation → confirm error snackbar appears
- [ ] After any tag mutation, switch to Vault tab → confirm tag counts are updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)