### PR TITLE
feat: unified TagPicker with hierarchy grouping and bottom sheet

### DIFF
--- a/lib/core/screens/note_detail_screen.dart
+++ b/lib/core/screens/note_detail_screen.dart
@@ -3,8 +3,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:parachute/core/models/thing.dart';
+import 'package:parachute/core/theme/design_tokens.dart';
 import 'package:parachute/core/widgets/note_audio_player.dart';
-import 'package:parachute/core/widgets/tag_input.dart';
+import 'package:parachute/core/widgets/tag_picker.dart';
+import 'package:parachute/core/widgets/tag_picker_sheet.dart';
 import 'package:parachute/features/daily/journal/providers/journal_providers.dart';
 import 'package:parachute/features/vault/providers/vault_providers.dart';
 
@@ -191,14 +193,20 @@ class _NoteDetailScreenState extends ConsumerState<NoteDetailScreen> {
           const SizedBox(height: 12),
         ],
         if (widget.note.tags.isNotEmpty) ...[
-          Wrap(
-            spacing: 6,
-            runSpacing: 4,
-            children: widget.note.tags.map((t) => Chip(
-              label: Text('#$t', style: theme.textTheme.labelSmall),
-              materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-              visualDensity: VisualDensity.compact,
-            )).toList(),
+          GestureDetector(
+            onTap: () => _openTagSheet(),
+            child: Wrap(
+              spacing: 6,
+              runSpacing: 4,
+              children: [
+                ...widget.note.tags.map((t) => _ReadOnlyTagChip(tag: t)),
+                Icon(
+                  Icons.edit_outlined,
+                  size: 14,
+                  color: theme.colorScheme.outline,
+                ),
+              ],
+            ),
           ),
           const SizedBox(height: 12),
         ],
@@ -233,7 +241,7 @@ class _NoteDetailScreenState extends ConsumerState<NoteDetailScreen> {
           onChanged: (_) => setState(() {}),
         ),
         const Divider(),
-        _TagInputWithSuggestions(
+        _TagPickerInline(
           tags: _tags,
           onChanged: (tags) => setState(() => _tags = tags),
         ),
@@ -254,6 +262,24 @@ class _NoteDetailScreenState extends ConsumerState<NoteDetailScreen> {
     );
   }
 
+  Future<void> _openTagSheet() async {
+    final result = await showTagPickerSheet(
+      context: context,
+      ref: ref,
+      currentTags: List<String>.from(_isEditing ? _tags : widget.note.tags),
+    );
+    if (result != null && mounted) {
+      setState(() {
+        _tags = result;
+        if (!_isEditing) {
+          // Apply immediately if in read mode
+          _isEditing = false;
+          _save();
+        }
+      });
+    }
+  }
+
   String _formatTimestamp(DateTime created, DateTime? updated) {
     final fmt = _fmtDate(created);
     if (updated != null && updated.isAfter(created)) {
@@ -268,24 +294,81 @@ class _NoteDetailScreenState extends ConsumerState<NoteDetailScreen> {
   }
 }
 
-/// TagInput wrapper that fetches vault tags for autocomplete suggestions.
-class _TagInputWithSuggestions extends ConsumerWidget {
+/// Inline TagPicker that fetches vault tags for suggestions.
+class _TagPickerInline extends ConsumerWidget {
   final List<String> tags;
   final void Function(List<String>) onChanged;
 
-  const _TagInputWithSuggestions({required this.tags, required this.onChanged});
+  const _TagPickerInline({required this.tags, required this.onChanged});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final tagsAsync = ref.watch(vaultTagsProvider);
-    final suggestions = tagsAsync.valueOrNull
-            ?.map((t) => t.tag)
+    final available = tagsAsync.valueOrNull
+            ?.map((t) => TagPickerItem(name: t.tag, count: t.count))
             .toList() ??
         [];
-    return TagInput(
-      tags: tags,
+    return TagPicker(
+      selectedTags: tags,
       onChanged: onChanged,
-      suggestions: suggestions,
+      availableTags: available,
+      compact: true,
+    );
+  }
+}
+
+/// Read-only tag chip with hierarchy-aware display.
+class _ReadOnlyTagChip extends StatelessWidget {
+  final String tag;
+  const _ReadOnlyTagChip({required this.tag});
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final parts = tag.split('/');
+    final isHierarchical = parts.length > 1;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 3),
+      decoration: BoxDecoration(
+        color: isDark
+            ? BrandColors.forest.withValues(alpha: 0.15)
+            : BrandColors.forestMist.withValues(alpha: 0.5),
+        borderRadius: BorderRadius.circular(Radii.sm),
+      ),
+      child: isHierarchical
+          ? Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  '#${parts.first}/',
+                  style: TextStyle(
+                    fontSize: TypographyTokens.labelSmall,
+                    color: isDark
+                        ? BrandColors.nightTextSecondary
+                        : BrandColors.driftwood,
+                  ),
+                ),
+                Text(
+                  parts.sublist(1).join('/'),
+                  style: TextStyle(
+                    fontSize: TypographyTokens.labelSmall,
+                    fontWeight: FontWeight.w500,
+                    color: isDark
+                        ? BrandColors.nightText
+                        : BrandColors.forest,
+                  ),
+                ),
+              ],
+            )
+          : Text(
+              '#$tag',
+              style: TextStyle(
+                fontSize: TypographyTokens.labelSmall,
+                fontWeight: FontWeight.w500,
+                color: isDark ? BrandColors.nightText : BrandColors.forest,
+              ),
+            ),
     );
   }
 }

--- a/lib/core/screens/note_detail_screen.dart
+++ b/lib/core/screens/note_detail_screen.dart
@@ -269,14 +269,11 @@ class _NoteDetailScreenState extends ConsumerState<NoteDetailScreen> {
       currentTags: List<String>.from(_isEditing ? _tags : widget.note.tags),
     );
     if (result != null && mounted) {
-      setState(() {
-        _tags = result;
-        if (!_isEditing) {
-          // Apply immediately if in read mode
-          _isEditing = false;
-          _save();
-        }
-      });
+      setState(() => _tags = result);
+      if (!_isEditing) {
+        // Save immediately when editing tags from read mode
+        await _save();
+      }
     }
   }
 

--- a/lib/core/widgets/tag_picker.dart
+++ b/lib/core/widgets/tag_picker.dart
@@ -153,7 +153,9 @@ class _TagPickerState extends State<TagPicker> {
 
         return AnimatedSize(
           duration: const Duration(milliseconds: 150),
-          child: Container(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 240),
+            child: Container(
             padding: const EdgeInsets.only(left: 10, right: 4, top: 4, bottom: 4),
             decoration: BoxDecoration(
               color: isDark
@@ -179,21 +181,27 @@ class _TagPickerState extends State<TagPicker> {
                           : BrandColors.driftwood,
                     ),
                   ),
-                  Text(
-                    parts.sublist(1).join('/'),
-                    style: TextStyle(
-                      fontSize: TypographyTokens.labelMedium,
-                      fontWeight: FontWeight.w500,
-                      color: isDark ? BrandColors.nightText : BrandColors.forest,
+                  Flexible(
+                    child: Text(
+                      parts.sublist(1).join('/'),
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        fontSize: TypographyTokens.labelMedium,
+                        fontWeight: FontWeight.w500,
+                        color: isDark ? BrandColors.nightText : BrandColors.forest,
+                      ),
                     ),
                   ),
                 ] else
-                  Text(
-                    tag,
-                    style: TextStyle(
-                      fontSize: TypographyTokens.labelMedium,
-                      fontWeight: FontWeight.w500,
-                      color: isDark ? BrandColors.nightText : BrandColors.forest,
+                  Flexible(
+                    child: Text(
+                      tag,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        fontSize: TypographyTokens.labelMedium,
+                        fontWeight: FontWeight.w500,
+                        color: isDark ? BrandColors.nightText : BrandColors.forest,
+                      ),
                     ),
                   ),
                 const SizedBox(width: 2),
@@ -209,6 +217,7 @@ class _TagPickerState extends State<TagPicker> {
                 ),
               ],
             ),
+          ),
           ),
         );
       }).toList(),
@@ -403,7 +412,7 @@ class _TagPickerState extends State<TagPicker> {
                   ),
                   if (totalCount > 0) ...[
                     Text(
-                      ' · ${totalCount}n',
+                      ' · $totalCount notes',
                       style: TextStyle(
                         fontSize: TypographyTokens.labelSmall,
                         color: isDark
@@ -452,7 +461,7 @@ class _TagPickerState extends State<TagPicker> {
         padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 5),
         decoration: BoxDecoration(
           color: isDark
-              ? BrandColors.charcoal.withValues(alpha: 0.4)
+              ? BrandColors.charcoal.withValues(alpha: 0.6)
               : BrandColors.stone.withValues(alpha: 0.3),
           borderRadius: BorderRadius.circular(Radii.sm),
         ),

--- a/lib/core/widgets/tag_picker.dart
+++ b/lib/core/widgets/tag_picker.dart
@@ -1,0 +1,497 @@
+import 'package:flutter/material.dart';
+import 'package:parachute/core/theme/design_tokens.dart';
+
+/// Tag info with optional count, for display in the picker.
+class TagPickerItem {
+  final String name;
+  final int count;
+
+  const TagPickerItem({required this.name, this.count = 0});
+}
+
+/// Unified tag picker with hierarchy grouping, counts, and search.
+///
+/// Shows selected tags as removable chips, a search field that filters
+/// available tags, and groups hierarchical tags (e.g. reader/summary)
+/// under collapsible parent headers.
+class TagPicker extends StatefulWidget {
+  /// Currently selected tags.
+  final List<String> selectedTags;
+
+  /// Called when tags change (add or remove).
+  final void Function(List<String> tags) onChanged;
+
+  /// All available tags from the vault (with counts).
+  final List<TagPickerItem> availableTags;
+
+  /// Whether to show in compact inline mode (for editors) vs full mode (sheets).
+  final bool compact;
+
+  const TagPicker({
+    super.key,
+    required this.selectedTags,
+    required this.onChanged,
+    this.availableTags = const [],
+    this.compact = false,
+  });
+
+  @override
+  State<TagPicker> createState() => _TagPickerState();
+}
+
+class _TagPickerState extends State<TagPicker> {
+  final _searchController = TextEditingController();
+  final _searchFocus = FocusNode();
+  final _expandedGroups = <String>{};
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    _searchFocus.dispose();
+    super.dispose();
+  }
+
+  void _addTag(String tag) {
+    if (widget.selectedTags.contains(tag)) return;
+    widget.onChanged([...widget.selectedTags, tag]);
+    _searchController.clear();
+    setState(() {});
+  }
+
+  void _removeTag(String tag) {
+    widget.onChanged(widget.selectedTags.where((t) => t != tag).toList());
+  }
+
+  void _addCustomTag() {
+    final raw = _searchController.text.trim();
+    if (raw.isEmpty) return;
+    final tag = raw.toLowerCase().replaceAll(' ', '-');
+    if (!RegExp(r'^[a-z0-9](?:[a-z0-9\-/]{0,46}[a-z0-9])?$').hasMatch(tag)) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Tags: lowercase letters, numbers, hyphens, slashes'),
+          duration: Duration(seconds: 2),
+        ),
+      );
+      return;
+    }
+    _addTag(tag);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+    final query = _searchController.text.toLowerCase();
+
+    // Filter available tags by search query, exclude already selected
+    final unselected = widget.availableTags
+        .where((t) => !widget.selectedTags.contains(t.name))
+        .where((t) => query.isEmpty || t.name.contains(query))
+        .toList();
+
+    // Group by prefix (before /)
+    final grouped = _groupTags(unselected);
+    final ungrouped = unselected.where((t) => !t.name.contains('/')).toList();
+
+    // Check if query matches any existing tag exactly
+    final exactMatch = widget.availableTags.any((t) => t.name == query) ||
+        widget.selectedTags.contains(query);
+    final showCreateOption =
+        query.isNotEmpty && !exactMatch && query.length >= 2;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        // Selected tags as removable chips
+        if (widget.selectedTags.isNotEmpty) ...[
+          _buildSelectedChips(theme, isDark),
+          SizedBox(height: widget.compact ? 8 : 12),
+        ],
+
+        // Search field
+        _buildSearchField(theme, isDark),
+
+        // Tag suggestions / browser
+        if (query.isNotEmpty || !widget.compact) ...[
+          SizedBox(height: widget.compact ? 4 : 8),
+          if (showCreateOption) _buildCreateOption(theme, isDark, query),
+          if (ungrouped.isNotEmpty) _buildFlatTags(theme, isDark, ungrouped),
+          ...grouped.entries.map(
+            (e) => _buildTagGroup(theme, isDark, e.key, e.value),
+          ),
+          if (unselected.isEmpty && query.isNotEmpty && !showCreateOption)
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 12),
+              child: Text(
+                'No matching tags',
+                style: TextStyle(
+                  color: isDark
+                      ? BrandColors.nightTextSecondary
+                      : BrandColors.driftwood,
+                  fontSize: TypographyTokens.bodySmall,
+                ),
+              ),
+            ),
+        ],
+      ],
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Selected chips
+  // ---------------------------------------------------------------------------
+
+  Widget _buildSelectedChips(ThemeData theme, bool isDark) {
+    return Wrap(
+      spacing: 6,
+      runSpacing: 6,
+      children: widget.selectedTags.map((tag) {
+        final parts = tag.split('/');
+        final isHierarchical = parts.length > 1;
+
+        return AnimatedSize(
+          duration: const Duration(milliseconds: 150),
+          child: Container(
+            padding: const EdgeInsets.only(left: 10, right: 4, top: 4, bottom: 4),
+            decoration: BoxDecoration(
+              color: isDark
+                  ? BrandColors.forest.withValues(alpha: 0.2)
+                  : BrandColors.forestMist.withValues(alpha: 0.6),
+              borderRadius: BorderRadius.circular(Radii.sm),
+              border: Border.all(
+                color: isDark
+                    ? BrandColors.forest.withValues(alpha: 0.3)
+                    : BrandColors.forest.withValues(alpha: 0.15),
+              ),
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                if (isHierarchical) ...[
+                  Text(
+                    '${parts.first}/',
+                    style: TextStyle(
+                      fontSize: TypographyTokens.labelSmall,
+                      color: isDark
+                          ? BrandColors.nightTextSecondary
+                          : BrandColors.driftwood,
+                    ),
+                  ),
+                  Text(
+                    parts.sublist(1).join('/'),
+                    style: TextStyle(
+                      fontSize: TypographyTokens.labelMedium,
+                      fontWeight: FontWeight.w500,
+                      color: isDark ? BrandColors.nightText : BrandColors.forest,
+                    ),
+                  ),
+                ] else
+                  Text(
+                    tag,
+                    style: TextStyle(
+                      fontSize: TypographyTokens.labelMedium,
+                      fontWeight: FontWeight.w500,
+                      color: isDark ? BrandColors.nightText : BrandColors.forest,
+                    ),
+                  ),
+                const SizedBox(width: 2),
+                GestureDetector(
+                  onTap: () => _removeTag(tag),
+                  child: Icon(
+                    Icons.close_rounded,
+                    size: 16,
+                    color: isDark
+                        ? BrandColors.nightTextSecondary
+                        : BrandColors.driftwood,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      }).toList(),
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Search field
+  // ---------------------------------------------------------------------------
+
+  Widget _buildSearchField(ThemeData theme, bool isDark) {
+    return TextField(
+      controller: _searchController,
+      focusNode: _searchFocus,
+      style: TextStyle(
+        fontSize: TypographyTokens.bodySmall,
+        color: isDark ? BrandColors.nightText : BrandColors.ink,
+      ),
+      decoration: InputDecoration(
+        hintText: 'Search or create tag...',
+        hintStyle: TextStyle(
+          color: isDark ? BrandColors.nightTextSecondary : BrandColors.driftwood,
+        ),
+        prefixIcon: Icon(
+          Icons.tag_rounded,
+          size: 18,
+          color: isDark ? BrandColors.nightTextSecondary : BrandColors.driftwood,
+        ),
+        prefixIconConstraints: const BoxConstraints(minWidth: 36),
+        isDense: true,
+        contentPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(Radii.sm),
+          borderSide: BorderSide(
+            color: isDark ? BrandColors.charcoal : BrandColors.stone,
+          ),
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(Radii.sm),
+          borderSide: BorderSide(
+            color: isDark ? BrandColors.charcoal : BrandColors.stone,
+          ),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(Radii.sm),
+          borderSide: BorderSide(color: BrandColors.turquoise, width: 1.5),
+        ),
+      ),
+      onSubmitted: (_) => _addCustomTag(),
+      onChanged: (_) => setState(() {}),
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Create new tag option
+  // ---------------------------------------------------------------------------
+
+  Widget _buildCreateOption(ThemeData theme, bool isDark, String query) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 4),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(Radii.sm),
+        onTap: _addCustomTag,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
+          child: Row(
+            children: [
+              Icon(
+                Icons.add_circle_outline_rounded,
+                size: 18,
+                color: BrandColors.turquoise,
+              ),
+              const SizedBox(width: 8),
+              Text(
+                'Create ',
+                style: TextStyle(
+                  fontSize: TypographyTokens.bodySmall,
+                  color: isDark
+                      ? BrandColors.nightTextSecondary
+                      : BrandColors.driftwood,
+                ),
+              ),
+              Container(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                decoration: BoxDecoration(
+                  color: BrandColors.turquoise.withValues(alpha: 0.1),
+                  borderRadius: BorderRadius.circular(4),
+                ),
+                child: Text(
+                  '#$query',
+                  style: TextStyle(
+                    fontSize: TypographyTokens.bodySmall,
+                    fontWeight: FontWeight.w600,
+                    color: isDark
+                        ? BrandColors.nightTurquoise
+                        : BrandColors.turquoiseDeep,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Flat (non-hierarchical) tags
+  // ---------------------------------------------------------------------------
+
+  Widget _buildFlatTags(
+      ThemeData theme, bool isDark, List<TagPickerItem> tags) {
+    return Wrap(
+      spacing: 6,
+      runSpacing: 6,
+      children: tags.map((t) => _buildTagChip(theme, isDark, t)).toList(),
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Hierarchical tag group
+  // ---------------------------------------------------------------------------
+
+  Map<String, List<TagPickerItem>> _groupTags(List<TagPickerItem> tags) {
+    final groups = <String, List<TagPickerItem>>{};
+    for (final tag in tags) {
+      final slashIndex = tag.name.indexOf('/');
+      if (slashIndex == -1) continue;
+      final prefix = tag.name.substring(0, slashIndex);
+      groups.putIfAbsent(prefix, () => []).add(tag);
+    }
+    return groups;
+  }
+
+  Widget _buildTagGroup(ThemeData theme, bool isDark, String prefix,
+      List<TagPickerItem> children) {
+    final isExpanded = _expandedGroups.contains(prefix);
+    final totalCount = children.fold<int>(0, (sum, t) => sum + t.count);
+
+    return Padding(
+      padding: const EdgeInsets.only(top: 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          InkWell(
+            borderRadius: BorderRadius.circular(Radii.sm),
+            onTap: () {
+              setState(() {
+                if (isExpanded) {
+                  _expandedGroups.remove(prefix);
+                } else {
+                  _expandedGroups.add(prefix);
+                }
+              });
+            },
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 6),
+              child: Row(
+                children: [
+                  AnimatedRotation(
+                    turns: isExpanded ? 0.25 : 0,
+                    duration: const Duration(milliseconds: 150),
+                    child: Icon(
+                      Icons.chevron_right_rounded,
+                      size: 18,
+                      color: isDark
+                          ? BrandColors.nightTextSecondary
+                          : BrandColors.driftwood,
+                    ),
+                  ),
+                  const SizedBox(width: 4),
+                  Text(
+                    '$prefix/',
+                    style: TextStyle(
+                      fontSize: TypographyTokens.labelMedium,
+                      fontWeight: FontWeight.w600,
+                      color: isDark
+                          ? BrandColors.nightTextSecondary
+                          : BrandColors.charcoal,
+                    ),
+                  ),
+                  const SizedBox(width: 6),
+                  Text(
+                    '${children.length}',
+                    style: TextStyle(
+                      fontSize: TypographyTokens.labelSmall,
+                      color: isDark
+                          ? BrandColors.nightTextSecondary.withValues(alpha: 0.6)
+                          : BrandColors.driftwood.withValues(alpha: 0.6),
+                    ),
+                  ),
+                  if (totalCount > 0) ...[
+                    Text(
+                      ' · ${totalCount}n',
+                      style: TextStyle(
+                        fontSize: TypographyTokens.labelSmall,
+                        color: isDark
+                            ? BrandColors.nightTextSecondary
+                                .withValues(alpha: 0.5)
+                            : BrandColors.driftwood.withValues(alpha: 0.5),
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ),
+          // Children — always show when searching, otherwise respect expand state
+          if (isExpanded || _searchController.text.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.only(left: 26, top: 4),
+              child: Wrap(
+                spacing: 6,
+                runSpacing: 6,
+                children: children
+                    .map((t) => _buildTagChip(theme, isDark, t,
+                        hidePrefix: prefix))
+                    .toList(),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Individual tag chip (in suggestions list)
+  // ---------------------------------------------------------------------------
+
+  Widget _buildTagChip(ThemeData theme, bool isDark, TagPickerItem tag,
+      {String? hidePrefix}) {
+    // Show just the suffix when nested under a group header
+    final displayName = hidePrefix != null && tag.name.startsWith('$hidePrefix/')
+        ? tag.name.substring(hidePrefix.length + 1)
+        : tag.name;
+
+    return GestureDetector(
+      onTap: () => _addTag(tag.name),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 5),
+        decoration: BoxDecoration(
+          color: isDark
+              ? BrandColors.charcoal.withValues(alpha: 0.4)
+              : BrandColors.stone.withValues(alpha: 0.3),
+          borderRadius: BorderRadius.circular(Radii.sm),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              '#$displayName',
+              style: TextStyle(
+                fontSize: TypographyTokens.labelMedium,
+                fontWeight: FontWeight.w500,
+                color: isDark ? BrandColors.nightText : BrandColors.charcoal,
+              ),
+            ),
+            if (tag.count > 0) ...[
+              const SizedBox(width: 4),
+              Container(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 4, vertical: 1),
+                decoration: BoxDecoration(
+                  color: isDark
+                      ? BrandColors.nightSurfaceElevated
+                      : BrandColors.stone.withValues(alpha: 0.5),
+                  borderRadius: BorderRadius.circular(4),
+                ),
+                child: Text(
+                  '${tag.count}',
+                  style: TextStyle(
+                    fontSize: TypographyTokens.labelSmall - 1,
+                    color: isDark
+                        ? BrandColors.nightTextSecondary
+                        : BrandColors.driftwood,
+                  ),
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/core/widgets/tag_picker_sheet.dart
+++ b/lib/core/widgets/tag_picker_sheet.dart
@@ -49,6 +49,7 @@ class _TagPickerSheetBodyState extends State<_TagPickerSheetBody> {
     final isDark = theme.brightness == Brightness.dark;
     final screenHeight = MediaQuery.of(context).size.height;
     final tagsAsync = widget.ref.watch(vaultTagsProvider);
+    final isLoading = tagsAsync.isLoading;
 
     final available = tagsAsync.valueOrNull
             ?.map((t) => TagPickerItem(name: t.tag, count: t.count))
@@ -117,14 +118,25 @@ class _TagPickerSheetBodyState extends State<_TagPickerSheetBody> {
 
           // Picker body (scrollable)
           Flexible(
-            child: SingleChildScrollView(
-              padding: const EdgeInsets.fromLTRB(20, 0, 20, 24),
-              child: TagPicker(
-                selectedTags: _tags,
-                onChanged: (tags) => setState(() => _tags = tags),
-                availableTags: available,
-              ),
-            ),
+            child: isLoading && available.isEmpty
+                ? const Padding(
+                    padding: EdgeInsets.all(32),
+                    child: Center(
+                      child: SizedBox(
+                        width: 24,
+                        height: 24,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      ),
+                    ),
+                  )
+                : SingleChildScrollView(
+                    padding: const EdgeInsets.fromLTRB(20, 0, 20, 24),
+                    child: TagPicker(
+                      selectedTags: _tags,
+                      onChanged: (tags) => setState(() => _tags = tags),
+                      availableTags: available,
+                    ),
+                  ),
           ),
         ],
       ),

--- a/lib/core/widgets/tag_picker_sheet.dart
+++ b/lib/core/widgets/tag_picker_sheet.dart
@@ -1,0 +1,133 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:parachute/core/theme/design_tokens.dart';
+import 'package:parachute/core/widgets/tag_picker.dart';
+import 'package:parachute/features/vault/providers/vault_providers.dart';
+
+/// Show a bottom sheet tag picker that fetches available tags from the vault.
+///
+/// Returns the updated tag list when dismissed, or null if unchanged.
+Future<List<String>?> showTagPickerSheet({
+  required BuildContext context,
+  required WidgetRef ref,
+  required List<String> currentTags,
+}) {
+  return showModalBottomSheet<List<String>>(
+    context: context,
+    isScrollControlled: true,
+    useSafeArea: true,
+    backgroundColor: Colors.transparent,
+    builder: (_) => _TagPickerSheetBody(
+      ref: ref,
+      initialTags: currentTags,
+    ),
+  );
+}
+
+class _TagPickerSheetBody extends StatefulWidget {
+  final WidgetRef ref;
+  final List<String> initialTags;
+
+  const _TagPickerSheetBody({required this.ref, required this.initialTags});
+
+  @override
+  State<_TagPickerSheetBody> createState() => _TagPickerSheetBodyState();
+}
+
+class _TagPickerSheetBodyState extends State<_TagPickerSheetBody> {
+  late List<String> _tags;
+
+  @override
+  void initState() {
+    super.initState();
+    _tags = List<String>.from(widget.initialTags);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+    final screenHeight = MediaQuery.of(context).size.height;
+    final tagsAsync = widget.ref.watch(vaultTagsProvider);
+
+    final available = tagsAsync.valueOrNull
+            ?.map((t) => TagPickerItem(name: t.tag, count: t.count))
+            .toList() ??
+        [];
+
+    return Container(
+      constraints: BoxConstraints(maxHeight: screenHeight * 0.7),
+      decoration: BoxDecoration(
+        color: isDark ? BrandColors.nightSurface : BrandColors.softWhite,
+        borderRadius: const BorderRadius.vertical(
+          top: Radius.circular(Radii.xl),
+        ),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          // Drag handle
+          Padding(
+            padding: const EdgeInsets.only(top: 8),
+            child: Container(
+              width: 36,
+              height: 4,
+              decoration: BoxDecoration(
+                color: isDark
+                    ? BrandColors.charcoal
+                    : BrandColors.stone,
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+          ),
+
+          // Header
+          Padding(
+            padding: const EdgeInsets.fromLTRB(20, 16, 12, 0),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    'Tags',
+                    style: TextStyle(
+                      fontSize: TypographyTokens.headlineSmall,
+                      fontWeight: FontWeight.w600,
+                      color: isDark ? BrandColors.nightText : BrandColors.ink,
+                    ),
+                  ),
+                ),
+                TextButton(
+                  onPressed: () => Navigator.pop(context, _tags),
+                  child: Text(
+                    'Done',
+                    style: TextStyle(
+                      fontSize: TypographyTokens.bodyMedium,
+                      fontWeight: FontWeight.w600,
+                      color: isDark
+                          ? BrandColors.nightTurquoise
+                          : BrandColors.turquoise,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+
+          const Divider(height: 16),
+
+          // Picker body (scrollable)
+          Flexible(
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.fromLTRB(20, 0, 20, 24),
+              child: TagPicker(
+                selectedTags: _tags,
+                onChanged: (tags) => setState(() => _tags = tags),
+                availableTags: available,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/daily/journal/screens/entry_detail_screen.dart
+++ b/lib/features/daily/journal/screens/entry_detail_screen.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:parachute/core/theme/design_tokens.dart';
-import 'package:parachute/core/widgets/tag_input.dart';
+import 'package:parachute/core/widgets/tag_picker.dart';
 import '../models/journal_entry.dart';
 
 /// Result returned when composing a new entry via Navigator.pop.
@@ -331,26 +331,60 @@ class _EntryDetailScreenState extends ConsumerState<EntryDetailScreen> {
           // Content (rendered markdown)
           _buildRenderedContent(theme, isDark, entry),
 
-          // Tags (read-only chips)
+          // Tags (read-only chips with hierarchy display)
           if (_tags.isNotEmpty) ...[
             const SizedBox(height: 24),
             Wrap(
-              spacing: 8,
+              spacing: 6,
               runSpacing: 6,
-              children: _tags.map((tag) => Chip(
-                label: Text(
-                  tag,
-                  style: TextStyle(
-                    fontSize: 13,
-                    color: isDark ? BrandColors.stone : BrandColors.charcoal,
+              children: _tags.map((tag) {
+                final parts = tag.split('/');
+                final isHierarchical = parts.length > 1;
+                return Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                  decoration: BoxDecoration(
+                    color: isDark
+                        ? BrandColors.forest.withValues(alpha: 0.15)
+                        : BrandColors.forestMist.withValues(alpha: 0.5),
+                    borderRadius: BorderRadius.circular(Radii.sm),
                   ),
-                ),
-                backgroundColor: isDark
-                    ? BrandColors.charcoal.withValues(alpha: 0.5)
-                    : BrandColors.stone.withValues(alpha: 0.3),
-                side: BorderSide.none,
-                visualDensity: VisualDensity.compact,
-              )).toList(),
+                  child: isHierarchical
+                      ? Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Text(
+                              '#${parts.first}/',
+                              style: TextStyle(
+                                fontSize: TypographyTokens.labelSmall,
+                                color: isDark
+                                    ? BrandColors.nightTextSecondary
+                                    : BrandColors.driftwood,
+                              ),
+                            ),
+                            Text(
+                              parts.sublist(1).join('/'),
+                              style: TextStyle(
+                                fontSize: TypographyTokens.labelSmall,
+                                fontWeight: FontWeight.w500,
+                                color: isDark
+                                    ? BrandColors.nightText
+                                    : BrandColors.forest,
+                              ),
+                            ),
+                          ],
+                        )
+                      : Text(
+                          '#$tag',
+                          style: TextStyle(
+                            fontSize: TypographyTokens.labelSmall,
+                            fontWeight: FontWeight.w500,
+                            color: isDark
+                                ? BrandColors.nightText
+                                : BrandColors.forest,
+                          ),
+                        ),
+                );
+              }).toList(),
             ),
           ],
 
@@ -542,15 +576,17 @@ class _EntryDetailScreenState extends ConsumerState<EntryDetailScreen> {
                   ),
                 ),
                 const SizedBox(height: 12),
-                TagInput(
-                  tags: _tags,
+                TagPicker(
+                  selectedTags: _tags,
                   onChanged: (updated) {
                     setState(() {
                       _tags = updated;
                     });
                   },
-                  suggestions: widget.allTags,
-                  hintText: 'Add a tag (e.g., "recipe", "work")...',
+                  availableTags: widget.allTags
+                      .map((t) => TagPickerItem(name: t))
+                      .toList(),
+                  compact: true,
                 ),
                 const SizedBox(height: 40),
               ],

--- a/lib/features/daily/journal/screens/entry_detail_screen.dart
+++ b/lib/features/daily/journal/screens/entry_detail_screen.dart
@@ -341,7 +341,7 @@ class _EntryDetailScreenState extends ConsumerState<EntryDetailScreen> {
                 final parts = tag.split('/');
                 final isHierarchical = parts.length > 1;
                 return Container(
-                  padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                  padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 3),
                   decoration: BoxDecoration(
                     color: isDark
                         ? BrandColors.forest.withValues(alpha: 0.15)


### PR DESCRIPTION
## Summary

Phase 2 of #57 (tag UI revamp). Builds on Phase 1 bug fixes (#85) with a redesigned tag picker:

- **New `TagPicker` widget** (`core/widgets/tag_picker.dart`) — hierarchy-aware tag display that groups `reader/summary`, `conductor/state` etc. under collapsible parent headers with chevron animation. Shows tag usage counts as subtle badges. Inline search/filter. Create-new-tag flow with validation.
- **`showTagPickerSheet()` bottom sheet** (`core/widgets/tag_picker_sheet.dart`) — modal that fetches vault tags, shows loading state, and returns updated tag list on dismiss. Clean drag handle + Done button.
- **NoteDetailScreen** — read-mode tags now tappable (pencil icon hint, opens tag sheet for quick editing without entering edit mode). Edit mode uses new TagPicker with compact layout.
- **EntryDetailScreen** — replaced old TagInput with TagPicker. Read-mode tags now use hierarchy-aware styling (prefix dimmed, leaf in forest accent).
- **Consistent visual language** — selected chips use forest/mist palette with hierarchy prefix dimming, suggested chips use neutral palette with count badges.

### Design decisions
- Hierarchical tags group by first `/` segment only (no nested groups for `a/b/c`)
- Groups auto-expand during search, respect manual expand/collapse otherwise
- Selected chips show full path with dimmed prefix; suggestion chips under a group show only the leaf
- Max chip width of 240px with text ellipsis prevents overflow with long names
- Bottom sheet caps at 70% screen height with scroll

## Test plan

- [ ] Open NoteDetailScreen in read mode → tap tags → tag sheet opens → modify → dismiss → tags persist
- [ ] Open NoteDetailScreen in edit mode → TagPicker shows inline with search + suggestions
- [ ] Type a partial tag name → autocomplete suggestions appear, filtered correctly
- [ ] Create a new tag via search field → tag appears in selected chips
- [ ] Hierarchical tags (e.g. `reader/summary`) group under `reader/` header with chevron
- [ ] Expand/collapse tag groups → smooth chevron rotation animation
- [ ] Tag counts show as subtle badges on suggestion chips
- [ ] Dark mode: verify contrast on all chip types (selected, suggested, group headers)
- [ ] Long tag names truncate with ellipsis, don't overflow
- [ ] EntryDetailScreen edit mode → TagPicker works with autocomplete
- [ ] EntryDetailScreen read mode → tags show hierarchy-aware styling
- [ ] Bottom sheet shows loading spinner while vault tags fetch
- [ ] Offline: tag sheet opens with empty suggestions, can still create new tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)