### PR TITLE
feat: render [[wikilinks]] as tappable links in note content

### DIFF
--- a/lib/core/screens/note_detail_screen.dart
+++ b/lib/core/screens/note_detail_screen.dart
@@ -2,9 +2,12 @@ import 'package:flutter/foundation.dart' show listEquals;
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:markdown/markdown.dart' as md;
 import 'package:parachute/core/models/thing.dart';
 import 'package:parachute/core/theme/design_tokens.dart';
 import 'package:parachute/core/widgets/note_audio_player.dart';
+import 'package:parachute/core/widgets/wikilink_handler.dart';
+import 'package:parachute/core/widgets/wikilink_syntax.dart';
 import 'package:parachute/core/widgets/tag_picker.dart';
 import 'package:parachute/core/widgets/tag_picker_sheet.dart';
 import 'package:parachute/features/daily/journal/providers/journal_providers.dart';
@@ -214,6 +217,19 @@ class _NoteDetailScreenState extends ConsumerState<NoteDetailScreen> {
         MarkdownBody(
           data: widget.note.content,
           selectable: true,
+          extensionSet: md.ExtensionSet(
+            [], [WikilinkSyntax()],
+          ),
+          builders: {
+            'wikilink': WikilinkBuilder(
+              onTap: (target) => handleWikilinkTap(
+                context: context,
+                api: ref.read(graphApiServiceProvider),
+                target: target,
+                onChanged: widget.onChanged,
+              ),
+            ),
+          },
           styleSheet: MarkdownStyleSheet.fromTheme(theme).copyWith(
             p: theme.textTheme.bodyLarge,
           ),

--- a/lib/core/screens/note_detail_screen.dart
+++ b/lib/core/screens/note_detail_screen.dart
@@ -2,7 +2,6 @@ import 'package:flutter/foundation.dart' show listEquals;
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:markdown/markdown.dart' as md;
 import 'package:parachute/core/models/thing.dart';
 import 'package:parachute/core/theme/design_tokens.dart';
 import 'package:parachute/core/widgets/note_audio_player.dart';
@@ -217,9 +216,7 @@ class _NoteDetailScreenState extends ConsumerState<NoteDetailScreen> {
         MarkdownBody(
           data: widget.note.content,
           selectable: true,
-          extensionSet: md.ExtensionSet(
-            [], [WikilinkSyntax()],
-          ),
+          inlineSyntaxes: [WikilinkSyntax()],
           builders: {
             'wikilink': WikilinkBuilder(
               onTap: (target) => handleWikilinkTap(

--- a/lib/core/widgets/wikilink_handler.dart
+++ b/lib/core/widgets/wikilink_handler.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:parachute/core/models/thing.dart';
+import 'package:parachute/core/screens/note_detail_screen.dart';
+import 'package:parachute/core/services/graph_api_service.dart';
+
+/// Resolves a wikilink target to a Note and navigates to it.
+///
+/// Searches by path first (exact match), then falls back to content search.
+/// Shows a snackbar if no matching note is found.
+Future<void> handleWikilinkTap({
+  required BuildContext context,
+  required GraphApiService api,
+  required String target,
+  VoidCallback? onChanged,
+}) async {
+  // Search for the note by its path/title
+  final results = await api.searchNotes(target, limit: 10);
+  if (results == null || results.isEmpty) {
+    if (context.mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Note not found: $target'),
+          duration: const Duration(seconds: 2),
+        ),
+      );
+    }
+    return;
+  }
+
+  // Find exact path match first, then title-contains match
+  final note = _findBestMatch(results, target);
+
+  if (!context.mounted) return;
+  Navigator.of(context).push(
+    MaterialPageRoute(
+      builder: (_) => NoteDetailScreen(
+        note: note,
+        onChanged: onChanged,
+      ),
+    ),
+  );
+}
+
+/// Find the best matching note for a wikilink target.
+///
+/// Priority: exact path match > case-insensitive path match > first result.
+Note _findBestMatch(List<Note> results, String target) {
+  final targetLower = target.toLowerCase();
+
+  // Exact path match
+  for (final note in results) {
+    if (note.path == target) return note;
+  }
+
+  // Case-insensitive path match
+  for (final note in results) {
+    if (note.path?.toLowerCase() == targetLower) return note;
+  }
+
+  // Path contains target
+  for (final note in results) {
+    if (note.path?.toLowerCase().contains(targetLower) == true) return note;
+  }
+
+  // Fall back to first search result
+  return results.first;
+}

--- a/lib/core/widgets/wikilink_handler.dart
+++ b/lib/core/widgets/wikilink_handler.dart
@@ -15,7 +15,15 @@ Future<void> handleWikilinkTap({
 }) async {
   // Search for the note by its path/title
   final results = await api.searchNotes(target, limit: 10);
-  if (results == null || results.isEmpty) {
+  if (results == null) {
+    if (context.mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Could not search — check connection')),
+      );
+    }
+    return;
+  }
+  if (results.isEmpty) {
     if (context.mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(

--- a/lib/core/widgets/wikilink_syntax.dart
+++ b/lib/core/widgets/wikilink_syntax.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
+import 'package:markdown/markdown.dart' as md;
+import 'package:parachute/core/theme/design_tokens.dart';
+
+/// Inline syntax that parses `[[target]]` and `[[target|display text]]`.
+///
+/// Produces an `md.Element` with tag 'wikilink', textContent = display text,
+/// and attribute 'target' = the link target path.
+class WikilinkSyntax extends md.InlineSyntax {
+  // Match [[ ... ]] with optional | for display text.
+  // Lazy match inside to handle [[a]] [[b]] correctly.
+  WikilinkSyntax() : super(r'\[\[([^\]]+?)\]\]');
+
+  @override
+  bool onMatch(md.InlineParser parser, Match match) {
+    final raw = match[1]!;
+    final pipeIndex = raw.indexOf('|');
+
+    String target;
+    String display;
+    if (pipeIndex != -1) {
+      target = raw.substring(0, pipeIndex).trim();
+      display = raw.substring(pipeIndex + 1).trim();
+    } else {
+      target = raw.trim();
+      display = target;
+    }
+
+    final el = md.Element.text('wikilink', display);
+    el.attributes['target'] = target;
+    parser.addNode(el);
+    return true;
+  }
+}
+
+/// Builder that renders wikilink elements as tappable styled text spans.
+class WikilinkBuilder extends MarkdownElementBuilder {
+  /// Called when a wikilink is tapped. Receives the target path.
+  final void Function(String target) onTap;
+
+  /// Set of known note paths (lowercase) for resolved/unresolved styling.
+  /// If null, all links render as resolved (optimistic).
+  final Set<String>? knownPaths;
+
+  WikilinkBuilder({required this.onTap, this.knownPaths});
+
+  @override
+  Widget? visitElementAfterWithContext(
+    BuildContext context,
+    md.Element element,
+    TextStyle? preferredStyle,
+    TextStyle? parentStyle,
+  ) {
+    final target = element.attributes['target'] ?? '';
+    final display = element.textContent;
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+
+    // Check if this link resolves to a known note
+    final isResolved = knownPaths == null ||
+        knownPaths!.contains(target.toLowerCase());
+
+    final color = isResolved
+        ? (isDark ? BrandColors.nightTurquoise : BrandColors.turquoiseDeep)
+        : (isDark
+            ? BrandColors.nightTextSecondary.withValues(alpha: 0.6)
+            : BrandColors.driftwood);
+
+    return RichText(
+      text: TextSpan(
+        text: display,
+        style: (preferredStyle ?? parentStyle)?.copyWith(
+              color: color,
+              decoration:
+                  isResolved ? TextDecoration.underline : TextDecoration.none,
+              decorationColor: color.withValues(alpha: 0.4),
+              decorationStyle: TextDecorationStyle.solid,
+              fontStyle: isResolved ? null : FontStyle.italic,
+            ) ??
+            TextStyle(color: color),
+        recognizer: TapGestureRecognizer()..onTap = () => onTap(target),
+      ),
+    );
+  }
+}

--- a/lib/core/widgets/wikilink_syntax.dart
+++ b/lib/core/widgets/wikilink_syntax.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
 import 'package:markdown/markdown.dart' as md;
@@ -67,20 +66,19 @@ class WikilinkBuilder extends MarkdownElementBuilder {
             ? BrandColors.nightTextSecondary.withValues(alpha: 0.6)
             : BrandColors.driftwood);
 
-    return RichText(
-      text: TextSpan(
-        text: display,
-        style: (preferredStyle ?? parentStyle)?.copyWith(
-              color: color,
-              decoration:
-                  isResolved ? TextDecoration.underline : TextDecoration.none,
-              decorationColor: color.withValues(alpha: 0.4),
-              decorationStyle: TextDecorationStyle.solid,
-              fontStyle: isResolved ? null : FontStyle.italic,
-            ) ??
-            TextStyle(color: color),
-        recognizer: TapGestureRecognizer()..onTap = () => onTap(target),
-      ),
+    final style = (preferredStyle ?? parentStyle)?.copyWith(
+          color: color,
+          decoration:
+              isResolved ? TextDecoration.underline : TextDecoration.none,
+          decorationColor: color.withValues(alpha: 0.4),
+          decorationStyle: TextDecorationStyle.solid,
+          fontStyle: isResolved ? null : FontStyle.italic,
+        ) ??
+        TextStyle(color: color);
+
+    return GestureDetector(
+      onTap: () => onTap(target),
+      child: Text(display, style: style),
     );
   }
 }

--- a/lib/features/daily/journal/screens/entry_detail_screen.dart
+++ b/lib/features/daily/journal/screens/entry_detail_screen.dart
@@ -2,8 +2,12 @@ import 'package:flutter/foundation.dart' show listEquals;
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:markdown/markdown.dart' as md;
 import 'package:parachute/core/theme/design_tokens.dart';
 import 'package:parachute/core/widgets/tag_picker.dart';
+import 'package:parachute/core/widgets/wikilink_handler.dart';
+import 'package:parachute/core/widgets/wikilink_syntax.dart';
+import 'package:parachute/features/daily/journal/providers/journal_providers.dart';
 import '../models/journal_entry.dart';
 
 /// Result returned when composing a new entry via Navigator.pop.
@@ -460,6 +464,18 @@ class _EntryDetailScreenState extends ConsumerState<EntryDetailScreen> {
       shrinkWrap: true,
       softLineBreak: true,
       selectable: true,
+      extensionSet: md.ExtensionSet(
+        [], [WikilinkSyntax()],
+      ),
+      builders: {
+        'wikilink': WikilinkBuilder(
+          onTap: (target) => handleWikilinkTap(
+            context: context,
+            api: ref.read(graphApiServiceProvider),
+            target: target,
+          ),
+        ),
+      },
       styleSheet: MarkdownStyleSheet(
         p: theme.textTheme.bodyLarge?.copyWith(
           color: isDark ? BrandColors.stone : BrandColors.charcoal,

--- a/lib/features/daily/journal/screens/entry_detail_screen.dart
+++ b/lib/features/daily/journal/screens/entry_detail_screen.dart
@@ -2,7 +2,6 @@ import 'package:flutter/foundation.dart' show listEquals;
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:markdown/markdown.dart' as md;
 import 'package:parachute/core/theme/design_tokens.dart';
 import 'package:parachute/core/widgets/tag_picker.dart';
 import 'package:parachute/core/widgets/wikilink_handler.dart';
@@ -464,9 +463,7 @@ class _EntryDetailScreenState extends ConsumerState<EntryDetailScreen> {
       shrinkWrap: true,
       softLineBreak: true,
       selectable: true,
-      extensionSet: md.ExtensionSet(
-        [], [WikilinkSyntax()],
-      ),
+      inlineSyntaxes: [WikilinkSyntax()],
       builders: {
         'wikilink': WikilinkBuilder(
           onTap: (target) => handleWikilinkTap(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -904,7 +904,7 @@ packages:
     source: hosted
     version: "0.3.0"
   markdown:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: markdown
       sha256: "935e23e1ff3bc02d390bad4d4be001208ee92cc217cb5b5a6c19bc14aaa318c1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
 
   # Markdown
   flutter_markdown_plus: ^1.0.7
+  markdown: ^7.0.0
 
   # Storage
   flutter_secure_storage: ^9.0.0


### PR DESCRIPTION
## Summary

Adds wikilink rendering to the Daily app. `[[Target Note]]` and `[[Target|Display Text]]` patterns in note content now render as tappable turquoise underlined links that navigate to the linked note.

- **`WikilinkSyntax`** (`core/widgets/wikilink_syntax.dart`) — custom `InlineSyntax` for the markdown parser that detects `[[...]]` patterns and supports the `|` alias separator
- **`WikilinkBuilder`** — `MarkdownElementBuilder` that renders wikilinks as tappable styled text. Resolved links: turquoise + underline. Unresolved links (optional, via `knownPaths`): dimmed + italic.
- **`handleWikilinkTap`** (`core/widgets/wikilink_handler.dart`) — resolves target via vault search API with best-match priority: exact path > case-insensitive path > path-contains > first result. Differentiates network errors from not-found.
- Wired into **NoteDetailScreen** and **EntryDetailScreen** via `inlineSyntaxes` param (adds to default GFM syntax, doesn't replace it)
- Added `markdown` as direct dependency in pubspec.yaml

### Design decisions
- Uses `inlineSyntaxes` (not `extensionSet`) to preserve all default GitHub-flavored markdown rendering
- Uses `GestureDetector` + `Text` instead of `TapGestureRecognizer` + `RichText` to avoid gesture recognizer lifecycle management issues
- Resolution via FTS5 search — good enough for v1, could add server-side path lookup later
- Unresolved link styling is built in but not active (all links render optimistic/resolved) — `knownPaths` parameter ready for future use

## Test plan

- [ ] Note with `[[Some Note]]` renders "Some Note" as tappable turquoise underlined text
- [ ] Note with `[[Target|Custom Text]]` renders "Custom Text" as the tappable link
- [ ] Tapping a wikilink navigates to the matching note's detail screen
- [ ] Multiple wikilinks on the same line all render and are independently tappable
- [ ] Wikilink to non-existent note shows "Note not found: Target" snackbar
- [ ] Wikilink tap while offline shows "Could not search — check connection" snackbar
- [ ] Standard markdown (bold, italic, links, code) still renders correctly alongside wikilinks
- [ ] Works in both NoteDetailScreen (Reader/Vault) and EntryDetailScreen (Capture)

🤖 Generated with [Claude Code](https://claude.com/claude-code)