### PR TITLE
fix: timezone-aware date handling for typed journal entries

### DIFF
--- a/lib/core/services/note_local_cache.dart
+++ b/lib/core/services/note_local_cache.dart
@@ -82,9 +82,11 @@ class NoteLocalCache {
         "created_at < ?",
         "COALESCE(sync_state, 'synced') != 'pending_delete'",
       ];
+      // Convert local date boundaries to UTC so the query matches the user's
+      // actual day (cache stores timestamps in UTC).
       final params = <Object>[
-        '${dateFrom}T00:00:00.000Z',
-        '${dateTo}T00:00:00.000Z',
+        DateTime.parse(dateFrom).toUtc().toIso8601String(),
+        DateTime.parse(dateTo).toUtc().toIso8601String(),
       ];
 
       if (tags != null && tags.isNotEmpty) {
@@ -346,7 +348,8 @@ class NoteLocalCache {
         "WHERE created_at >= ? AND created_at < ? "
         "AND COALESCE(sync_state, 'synced') = 'synced' "
         "AND id NOT IN ($placeholders)",
-        ['${dateFrom}T00:00:00.000Z', '${dateTo}T00:00:00.000Z', ...serverIds],
+        [DateTime.parse(dateFrom).toUtc().toIso8601String(),
+         DateTime.parse(dateTo).toUtc().toIso8601String(), ...serverIds],
       );
     } catch (e) {
       debugPrint('[NoteLocalCache] removeStaleNotes error: $e');
@@ -359,7 +362,8 @@ class NoteLocalCache {
       _db.execute(
         "DELETE FROM notes WHERE created_at >= ? AND created_at < ? "
         "AND COALESCE(sync_state, 'synced') = 'synced'",
-        ['${dateFrom}T00:00:00.000Z', '${dateTo}T00:00:00.000Z'],
+        [DateTime.parse(dateFrom).toUtc().toIso8601String(),
+         DateTime.parse(dateTo).toUtc().toIso8601String()],
       );
     } catch (e) {
       debugPrint('[NoteLocalCache] clearDateRange error: $e');

--- a/lib/core/services/note_local_cache.dart
+++ b/lib/core/services/note_local_cache.dart
@@ -84,9 +84,10 @@ class NoteLocalCache {
       ];
       // Convert local date boundaries to UTC so the query matches the user's
       // actual day (cache stores timestamps in UTC).
+      // DateTime.parse on date-only strings returns UTC, so construct local manually.
       final params = <Object>[
-        DateTime.parse(dateFrom).toUtc().toIso8601String(),
-        DateTime.parse(dateTo).toUtc().toIso8601String(),
+        _localMidnight(dateFrom).toUtc().toIso8601String(),
+        _localMidnight(dateTo).toUtc().toIso8601String(),
       ];
 
       if (tags != null && tags.isNotEmpty) {
@@ -348,8 +349,8 @@ class NoteLocalCache {
         "WHERE created_at >= ? AND created_at < ? "
         "AND COALESCE(sync_state, 'synced') = 'synced' "
         "AND id NOT IN ($placeholders)",
-        [DateTime.parse(dateFrom).toUtc().toIso8601String(),
-         DateTime.parse(dateTo).toUtc().toIso8601String(), ...serverIds],
+        [_localMidnight(dateFrom).toUtc().toIso8601String(),
+         _localMidnight(dateTo).toUtc().toIso8601String(), ...serverIds],
       );
     } catch (e) {
       debugPrint('[NoteLocalCache] removeStaleNotes error: $e');
@@ -362,12 +363,23 @@ class NoteLocalCache {
       _db.execute(
         "DELETE FROM notes WHERE created_at >= ? AND created_at < ? "
         "AND COALESCE(sync_state, 'synced') = 'synced'",
-        [DateTime.parse(dateFrom).toUtc().toIso8601String(),
-         DateTime.parse(dateTo).toUtc().toIso8601String()],
+        [_localMidnight(dateFrom).toUtc().toIso8601String(),
+         _localMidnight(dateTo).toUtc().toIso8601String()],
       );
     } catch (e) {
       debugPrint('[NoteLocalCache] clearDateRange error: $e');
     }
+  }
+
+  // ── Helpers ────────────────────────────────────────────────────────────────
+
+  /// Parse a YYYY-MM-DD string as local midnight.
+  ///
+  /// [DateTime.parse] on date-only strings returns UTC, so we split and
+  /// construct a local [DateTime] instead.
+  static DateTime _localMidnight(String date) {
+    final parts = date.split('-');
+    return DateTime(int.parse(parts[0]), int.parse(parts[1]), int.parse(parts[2]));
   }
 
   // ── Lifecycle ──────────────────────────────────────────────────────────────

--- a/lib/features/daily/journal/screens/journal_screen.dart
+++ b/lib/features/daily/journal/screens/journal_screen.dart
@@ -436,6 +436,7 @@ class _JournalScreenState extends ConsumerState<JournalScreen> with WidgetsBindi
     final api = ref.read(dailyApiServiceProvider);
     final entry = await api.createEntry(
       content: content,
+      createdAt: DateTime.now().toUtc(),
       metadata: {
         if (type != JournalEntryType.text) 'type': _entryTypeString(type),
         if (audioPath != null) 'audio_path': audioPath,

--- a/lib/features/daily/journal/services/daily_api_service.dart
+++ b/lib/features/daily/journal/services/daily_api_service.dart
@@ -87,12 +87,15 @@ class DailyApiService {
   /// Returns `null` on network error — callers should fall back to cache.
   /// Returns `[]` when the server responds with no notes — authoritative empty.
   Future<List<Note>?> getNotes({required String date, String? tag}) async {
-    final nextDate = _nextDate(date);
+    // Convert local date boundaries to UTC so the query matches the user's
+    // actual day regardless of timezone (server stores timestamps in UTC).
+    final localFrom = DateTime.parse(date);
+    final localTo = localFrom.add(const Duration(days: 1));
     final uri = Uri.parse('$baseUrl$_apiPrefix/notes').replace(
       queryParameters: {
         'tag': tag ?? captureTag,
-        'date_from': '${date}T00:00:00.000Z',
-        'date_to': '${nextDate}T00:00:00.000Z',
+        'date_from': localFrom.toUtc().toIso8601String(),
+        'date_to': localTo.toUtc().toIso8601String(),
         'limit': '100',
       },
     );
@@ -524,9 +527,6 @@ class DailyApiService {
       metadata: {},
     );
   }
-
-  /// Compute the next date string for date range queries.
-  static String _nextDate(String date) => nextDate(date);
 }
 
 /// Compute the next date string (YYYY-MM-DD) for date range queries.

--- a/lib/features/daily/journal/services/daily_api_service.dart
+++ b/lib/features/daily/journal/services/daily_api_service.dart
@@ -89,7 +89,8 @@ class DailyApiService {
   Future<List<Note>?> getNotes({required String date, String? tag}) async {
     // Convert local date boundaries to UTC so the query matches the user's
     // actual day regardless of timezone (server stores timestamps in UTC).
-    final localFrom = DateTime.parse(date);
+    // DateTime.parse on date-only strings returns UTC, so construct local manually.
+    final localFrom = _localMidnight(date);
     final localTo = localFrom.add(const Duration(days: 1));
     final uri = Uri.parse('$baseUrl$_apiPrefix/notes').replace(
       queryParameters: {
@@ -537,4 +538,13 @@ String nextDate(String date) {
   final m = next.month.toString().padLeft(2, '0');
   final d = next.day.toString().padLeft(2, '0');
   return '$y-$m-$d';
+}
+
+/// Parse a YYYY-MM-DD string as local midnight.
+///
+/// [DateTime.parse] on date-only strings returns UTC, so we split and
+/// construct a local [DateTime] instead.
+DateTime _localMidnight(String date) {
+  final parts = date.split('-');
+  return DateTime(int.parse(parts[0]), int.parse(parts[1]), int.parse(parts[2]));
 }


### PR DESCRIPTION
## Summary

- **Pass `createdAt: DateTime.now().toUtc()` for typed entries** — typed notes omitted `createdAt` when posting to the server, causing the server to assign a UTC timestamp. For users west of UTC, entries created in the evening landed on the next calendar day.
- **Convert local date boundaries to UTC in date range queries** — `getNotes`, `getNotesForDate`, `removeStaleNotes`, and `clearDateRange` all appended `T00:00:00.000Z` to local date strings, treating local midnight as UTC midnight. Now constructs local `DateTime` and converts to UTC, so queries correctly bound to the user's local day.
- Voice entries already passed `createdAt` and were not affected.

Fixes the recurring bug where typed notes get dated a day later than expected when created after 6pm MDT.

## Files changed

- `lib/features/daily/journal/screens/journal_screen.dart` — add `createdAt` to typed entry creation
- `lib/features/daily/journal/services/daily_api_service.dart` — local midnight → UTC in `getNotes`
- `lib/core/services/note_local_cache.dart` — local midnight → UTC in cache date queries

## Test plan

- [ ] Create a typed note in the evening (after 6pm local) — verify it appears under today, not tomorrow
- [ ] Navigate to previous days — verify entries still display correctly
- [ ] Voice notes unaffected — verify recording timestamps still correct
- [ ] Offline-created entries sync to correct date after reconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)