### PR TITLE
feat: wikilink disambiguation picker for ambiguous matches

### DIFF
--- a/lib/core/widgets/wikilink_handler.dart
+++ b/lib/core/widgets/wikilink_handler.dart
@@ -2,10 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:parachute/core/models/thing.dart';
 import 'package:parachute/core/screens/note_detail_screen.dart';
 import 'package:parachute/core/services/graph_api_service.dart';
+import 'package:parachute/core/theme/design_tokens.dart';
 
 /// Resolves a wikilink target to a Note and navigates to it.
 ///
 /// Searches by path first (exact match), then falls back to content search.
+/// When multiple notes match with similar relevance, shows a disambiguation
+/// bottom sheet so the user can pick the right one.
 /// Shows a snackbar if no matching note is found.
 Future<void> handleWikilinkTap({
   required BuildContext context,
@@ -35,10 +38,25 @@ Future<void> handleWikilinkTap({
     return;
   }
 
-  // Find exact path match first, then title-contains match
-  final note = _findBestMatch(results, target);
+  // Find matches ranked by relevance
+  final ranked = _rankMatches(results, target);
 
   if (!context.mounted) return;
+
+  // Single strong match → navigate directly
+  if (ranked.length == 1 || _isClearWinner(ranked)) {
+    _navigateToNote(context, ranked.first, onChanged);
+    return;
+  }
+
+  // Multiple ambiguous matches → show picker
+  final chosen = await _showDisambiguationSheet(context, target, ranked);
+  if (chosen != null && context.mounted) {
+    _navigateToNote(context, chosen, onChanged);
+  }
+}
+
+void _navigateToNote(BuildContext context, Note note, VoidCallback? onChanged) {
   Navigator.of(context).push(
     MaterialPageRoute(
       builder: (_) => NoteDetailScreen(
@@ -49,27 +67,131 @@ Future<void> handleWikilinkTap({
   );
 }
 
-/// Find the best matching note for a wikilink target.
+/// Rank search results by match quality against the target.
 ///
-/// Priority: exact path match > case-insensitive path match > first result.
-Note _findBestMatch(List<Note> results, String target) {
+/// Priority: exact path > case-insensitive path > path-contains > other.
+List<Note> _rankMatches(List<Note> results, String target) {
   final targetLower = target.toLowerCase();
 
-  // Exact path match
-  for (final note in results) {
-    if (note.path == target) return note;
+  int score(Note note) {
+    final path = note.path ?? '';
+    final pathLower = path.toLowerCase();
+    if (path == target) return 0; // exact
+    if (pathLower == targetLower) return 1; // case-insensitive exact
+    // Path ends with target (e.g., "People/Atlas" matches "Atlas")
+    if (pathLower.endsWith('/$targetLower')) return 2;
+    if (pathLower.contains(targetLower)) return 3; // contains
+    return 4; // content match only
   }
 
-  // Case-insensitive path match
-  for (final note in results) {
-    if (note.path?.toLowerCase() == targetLower) return note;
-  }
+  final sorted = List<Note>.from(results)..sort((a, b) => score(a).compareTo(score(b)));
+  return sorted;
+}
 
-  // Path contains target
-  for (final note in results) {
-    if (note.path?.toLowerCase().contains(targetLower) == true) return note;
-  }
+/// Returns true if the top result is clearly better than the rest.
+bool _isClearWinner(List<Note> ranked) {
+  if (ranked.length < 2) return true;
+  final first = ranked[0];
+  final second = ranked[1];
 
-  // Fall back to first search result
-  return results.first;
+  // If first has a path and second doesn't, clear winner
+  if ((first.path ?? '').isNotEmpty && (second.path ?? '').isEmpty) return true;
+
+  // If first is an exact path match, clear winner
+  final firstPath = first.path ?? '';
+  final secondPath = second.path ?? '';
+  if (firstPath == secondPath) return true;
+
+  return false;
+}
+
+/// Shows a bottom sheet with disambiguation options.
+Future<Note?> _showDisambiguationSheet(
+  BuildContext context,
+  String target,
+  List<Note> options,
+) {
+  return showModalBottomSheet<Note>(
+    context: context,
+    isScrollControlled: true,
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+    ),
+    builder: (ctx) {
+      final theme = Theme.of(ctx);
+      final isDark = theme.brightness == Brightness.dark;
+
+      return SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.only(top: 12, bottom: 8),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              // Drag handle
+              Container(
+                width: 36,
+                height: 4,
+                decoration: BoxDecoration(
+                  color: theme.colorScheme.outline.withValues(alpha: 0.4),
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+              const SizedBox(height: 16),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 20),
+                child: Text(
+                  'Multiple matches for "$target"',
+                  style: theme.textTheme.titleSmall?.copyWith(
+                    color: theme.colorScheme.outline,
+                  ),
+                ),
+              ),
+              const SizedBox(height: 12),
+              ...options.take(8).map((note) {
+                final path = note.path ?? '';
+                final display = path.isNotEmpty
+                    ? path
+                    : _snippetFromContent(note.content);
+
+                return ListTile(
+                  leading: Icon(
+                    Icons.description_outlined,
+                    color: isDark
+                        ? BrandColors.turquoiseLight
+                        : BrandColors.turquoiseDeep,
+                    size: 20,
+                  ),
+                  title: Text(
+                    display,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  subtitle: path.isNotEmpty && note.content.isNotEmpty
+                      ? Text(
+                          _snippetFromContent(note.content),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            color: theme.colorScheme.outline,
+                          ),
+                        )
+                      : null,
+                  onTap: () => Navigator.of(ctx).pop(note),
+                );
+              }),
+              const SizedBox(height: 8),
+            ],
+          ),
+        ),
+      );
+    },
+  );
+}
+
+String _snippetFromContent(String content) {
+  final trimmed = content.trim();
+  if (trimmed.isEmpty) return 'Untitled note';
+  final firstLine = trimmed.split('\n').first.replaceFirst(RegExp(r'^#+\s*'), '');
+  if (firstLine.length > 80) return '${firstLine.substring(0, 80)}...';
+  return firstLine;
 }

--- a/lib/core/widgets/wikilink_handler.dart
+++ b/lib/core/widgets/wikilink_handler.dart
@@ -44,7 +44,7 @@ Future<void> handleWikilinkTap({
   if (!context.mounted) return;
 
   // Single strong match → navigate directly
-  if (ranked.length == 1 || _isClearWinner(ranked)) {
+  if (ranked.length == 1 || _isClearWinner(ranked, target)) {
     _navigateToNote(context, ranked.first, onChanged);
     return;
   }
@@ -67,42 +67,31 @@ void _navigateToNote(BuildContext context, Note note, VoidCallback? onChanged) {
   );
 }
 
-/// Rank search results by match quality against the target.
+/// Score how well a note matches a wikilink target.
 ///
-/// Priority: exact path > case-insensitive path > path-contains > other.
-List<Note> _rankMatches(List<Note> results, String target) {
+/// Lower is better: 0 = exact path, 4 = content match only.
+int _matchScore(Note note, String target) {
+  final path = note.path ?? '';
+  final pathLower = path.toLowerCase();
   final targetLower = target.toLowerCase();
+  if (path == target) return 0; // exact
+  if (pathLower == targetLower) return 1; // case-insensitive exact
+  if (pathLower.endsWith('/$targetLower')) return 2; // path suffix
+  if (pathLower.contains(targetLower)) return 3; // contains
+  return 4; // content match only
+}
 
-  int score(Note note) {
-    final path = note.path ?? '';
-    final pathLower = path.toLowerCase();
-    if (path == target) return 0; // exact
-    if (pathLower == targetLower) return 1; // case-insensitive exact
-    // Path ends with target (e.g., "People/Atlas" matches "Atlas")
-    if (pathLower.endsWith('/$targetLower')) return 2;
-    if (pathLower.contains(targetLower)) return 3; // contains
-    return 4; // content match only
-  }
-
-  final sorted = List<Note>.from(results)..sort((a, b) => score(a).compareTo(score(b)));
+/// Rank search results by match quality against the target.
+List<Note> _rankMatches(List<Note> results, String target) {
+  final sorted = List<Note>.from(results)
+    ..sort((a, b) => _matchScore(a, target).compareTo(_matchScore(b, target)));
   return sorted;
 }
 
 /// Returns true if the top result is clearly better than the rest.
-bool _isClearWinner(List<Note> ranked) {
+bool _isClearWinner(List<Note> ranked, String target) {
   if (ranked.length < 2) return true;
-  final first = ranked[0];
-  final second = ranked[1];
-
-  // If first has a path and second doesn't, clear winner
-  if ((first.path ?? '').isNotEmpty && (second.path ?? '').isEmpty) return true;
-
-  // If first is an exact path match, clear winner
-  final firstPath = first.path ?? '';
-  final secondPath = second.path ?? '';
-  if (firstPath == secondPath) return true;
-
-  return false;
+  return _matchScore(ranked[0], target) < _matchScore(ranked[1], target);
 }
 
 /// Shows a bottom sheet with disambiguation options.


### PR DESCRIPTION
## Summary

- When a `[[wikilink]]` matches multiple notes with similar relevance (e.g., `People/Atlas` and `Projects/Atlas`), shows a bottom sheet picker instead of silently navigating to the first result
- Single clear matches still navigate directly (no UX change)
- Match scoring: exact path (0) > case-insensitive (1) > path suffix (2) > path contains (3) > content only (4)
- Clear winner = top score is strictly better than second score; otherwise disambiguation sheet shown
- Options show note path + content snippet, capped at 8 results

## Files changed

- `lib/core/widgets/wikilink_handler.dart` — rewritten with scoring, ranking, disambiguation sheet

## Test plan

- [ ] Tap a wikilink that matches exactly one note → direct navigation (no change)
- [ ] Tap `[[Atlas]]` where both `People/Atlas` and `Projects/Atlas` exist → bottom sheet picker shown
- [ ] Select an option from the picker → navigates to that note
- [ ] Dismiss the picker → no navigation
- [ ] Tap a wikilink with no matches → "not found" snackbar (no change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)