### PR TITLE
feat: note rename UI with inline dialog

### DIFF
--- a/lib/core/screens/note_detail_screen.dart
+++ b/lib/core/screens/note_detail_screen.dart
@@ -43,6 +43,7 @@ class _NoteDetailScreenState extends ConsumerState<NoteDetailScreen> {
   late String _originalTitle;
   late String _originalContent;
   late List<String> _originalTags;
+  late String _currentPath;
 
   bool _saving = false;
 
@@ -58,6 +59,7 @@ class _NoteDetailScreenState extends ConsumerState<NoteDetailScreen> {
     _originalTitle = widget.note.path ?? '';
     _originalContent = widget.note.content;
     _originalTags = List<String>.from(widget.note.tags);
+    _currentPath = _originalTitle;
     _titleController = TextEditingController(text: _originalTitle);
     _contentController = TextEditingController(text: _originalContent);
     _tags = List<String>.from(widget.note.tags);
@@ -187,7 +189,7 @@ class _NoteDetailScreenState extends ConsumerState<NoteDetailScreen> {
   }
 
   Widget _buildReader(ThemeData theme) {
-    final title = widget.note.path ?? '';
+    final title = _currentPath;
     return ListView(
       padding: const EdgeInsets.all(16),
       children: [
@@ -317,48 +319,53 @@ class _NoteDetailScreenState extends ConsumerState<NoteDetailScreen> {
 
   Future<void> _showRenameDialog(String currentPath) async {
     final controller = TextEditingController(text: currentPath);
-    final newPath = await showDialog<String>(
-      context: context,
-      builder: (ctx) {
-        final theme = Theme.of(ctx);
-        return AlertDialog(
-          title: const Text('Rename note'),
-          content: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                'Links in other notes will update automatically.',
-                style: theme.textTheme.bodySmall?.copyWith(
-                  color: theme.colorScheme.outline,
+    String? newPath;
+    try {
+      newPath = await showDialog<String>(
+        context: context,
+        builder: (ctx) {
+          final theme = Theme.of(ctx);
+          return AlertDialog(
+            title: const Text('Rename note'),
+            content: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Links in other notes will update automatically.',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.outline,
+                  ),
                 ),
+                const SizedBox(height: 12),
+                TextField(
+                  controller: controller,
+                  autofocus: true,
+                  decoration: const InputDecoration(
+                    labelText: 'Path',
+                    hintText: 'e.g. People/Atlas',
+                    border: OutlineInputBorder(),
+                  ),
+                  onSubmitted: (value) => Navigator.pop(ctx, value.trim()),
+                ),
+              ],
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(ctx),
+                child: const Text('Cancel'),
               ),
-              const SizedBox(height: 12),
-              TextField(
-                controller: controller,
-                autofocus: true,
-                decoration: const InputDecoration(
-                  labelText: 'Path',
-                  hintText: 'e.g. People/Atlas',
-                  border: OutlineInputBorder(),
-                ),
-                onSubmitted: (value) => Navigator.pop(ctx, value.trim()),
+              TextButton(
+                onPressed: () => Navigator.pop(ctx, controller.text.trim()),
+                child: const Text('Rename'),
               ),
             ],
-          ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(ctx),
-              child: const Text('Cancel'),
-            ),
-            TextButton(
-              onPressed: () => Navigator.pop(ctx, controller.text.trim()),
-              child: const Text('Rename'),
-            ),
-          ],
-        );
-      },
-    );
+          );
+        },
+      );
+    } finally {
+      controller.dispose();
+    }
 
     if (newPath == null || newPath.isEmpty || newPath == currentPath) return;
     if (!mounted) return;
@@ -368,8 +375,8 @@ class _NoteDetailScreenState extends ConsumerState<NoteDetailScreen> {
 
     if (!mounted) return;
     if (result != null) {
-      // Update local state to reflect the rename
       _originalTitle = newPath;
+      _currentPath = newPath;
       _titleController.text = newPath;
       setState(() {});
       widget.onChanged?.call();

--- a/lib/core/screens/note_detail_screen.dart
+++ b/lib/core/screens/note_detail_screen.dart
@@ -192,7 +192,27 @@ class _NoteDetailScreenState extends ConsumerState<NoteDetailScreen> {
       padding: const EdgeInsets.all(16),
       children: [
         if (title.isNotEmpty) ...[
-          Text(title, style: theme.textTheme.headlineSmall),
+          GestureDetector(
+            onLongPress: () => _showRenameDialog(title),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Text(title, style: theme.textTheme.headlineSmall),
+                ),
+                GestureDetector(
+                  onTap: () => _showRenameDialog(title),
+                  child: Padding(
+                    padding: const EdgeInsets.all(4),
+                    child: Icon(
+                      Icons.drive_file_rename_outline,
+                      size: 18,
+                      color: theme.colorScheme.outline,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
           const SizedBox(height: 12),
         ],
         if (widget.note.tags.isNotEmpty) ...[
@@ -292,6 +312,74 @@ class _NoteDetailScreenState extends ConsumerState<NoteDetailScreen> {
         // Save immediately when editing tags from read mode
         await _save();
       }
+    }
+  }
+
+  Future<void> _showRenameDialog(String currentPath) async {
+    final controller = TextEditingController(text: currentPath);
+    final newPath = await showDialog<String>(
+      context: context,
+      builder: (ctx) {
+        final theme = Theme.of(ctx);
+        return AlertDialog(
+          title: const Text('Rename note'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'Links in other notes will update automatically.',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.outline,
+                ),
+              ),
+              const SizedBox(height: 12),
+              TextField(
+                controller: controller,
+                autofocus: true,
+                decoration: const InputDecoration(
+                  labelText: 'Path',
+                  hintText: 'e.g. People/Atlas',
+                  border: OutlineInputBorder(),
+                ),
+                onSubmitted: (value) => Navigator.pop(ctx, value.trim()),
+              ),
+            ],
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(ctx),
+              child: const Text('Cancel'),
+            ),
+            TextButton(
+              onPressed: () => Navigator.pop(ctx, controller.text.trim()),
+              child: const Text('Rename'),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (newPath == null || newPath.isEmpty || newPath == currentPath) return;
+    if (!mounted) return;
+
+    final api = ref.read(graphApiServiceProvider);
+    final result = await api.updateNote(widget.note.id, path: newPath);
+
+    if (!mounted) return;
+    if (result != null) {
+      // Update local state to reflect the rename
+      _originalTitle = newPath;
+      _titleController.text = newPath;
+      setState(() {});
+      widget.onChanged?.call();
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Renamed to $newPath')),
+      );
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Rename failed — check connection')),
+      );
     }
   }
 


### PR DESCRIPTION
## Summary

- Add rename capability to `NoteDetailScreen` — small rename icon next to the title in read mode, or long-press the title
- Opens a dialog with the current path pre-filled and hint text ("e.g. People/Atlas")
- Includes note: "Links in other notes will update automatically" (vault handles cascade server-side)
- On save, calls `PATCH /api/notes/:id` with the new path
- Shows confirmation snackbar on success, error on failure
- Tracks `_currentPath` locally so the title updates immediately without requiring full widget rebuild

## Files changed

- `lib/core/screens/note_detail_screen.dart` — rename dialog, `_currentPath` field, tappable title with icon

## Test plan

- [ ] Long-press a note title → rename dialog opens with current path
- [ ] Tap the rename icon → same dialog
- [ ] Enter a new path and tap Rename → path updates, snackbar confirms
- [ ] Cancel the dialog → no changes
- [ ] Enter empty path → no API call
- [ ] Rename while offline → error snackbar
- [ ] Rename then re-open dialog → shows the new path, not the old one

🤖 Generated with [Claude Code](https://claude.com/claude-code)