### PR TITLE
fix: preserve digest list scroll position after archive

### DIFF
--- a/lib/features/digest/screens/digest_screen.dart
+++ b/lib/features/digest/screens/digest_screen.dart
@@ -24,6 +24,14 @@ class DigestScreen extends ConsumerStatefulWidget {
 }
 
 class _DigestScreenState extends ConsumerState<DigestScreen> {
+  final _scrollController = ScrollController();
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
   void _refresh() {
     ref.read(digestRefreshTriggerProvider.notifier).state++;
   }
@@ -109,6 +117,7 @@ class _DigestScreenState extends ConsumerState<DigestScreen> {
         (sortedKeys.length == 1 && sortedKeys.first.isNotEmpty);
 
     return ListView.builder(
+      controller: _scrollController,
       padding: const EdgeInsets.symmetric(vertical: 4),
       itemCount: sortedKeys.length,
       itemBuilder: (context, sectionIndex) {


### PR DESCRIPTION
## Summary

- Add a persistent `ScrollController` to `DigestScreen` so the `ListView` retains its scroll offset when the list rebuilds after archiving/unarchiving a note
- Previously, each rebuild created a fresh `ListView.builder` that started at offset 0, forcing the user to scroll back down

## Test plan

- [ ] Scroll down in the digest list, archive a note → list stays at the same position
- [ ] Undo archive → list stays at position
- [ ] Pull-to-refresh → scroll position resets (expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)