### PR TITLE
feat: display and edit note metadata with tag schema awareness

### DIFF
--- a/lib/core/screens/note_detail_screen.dart
+++ b/lib/core/screens/note_detail_screen.dart
@@ -6,6 +6,7 @@ import 'package:parachute/core/models/thing.dart';
 import 'package:parachute/core/theme/design_tokens.dart';
 import 'package:parachute/core/widgets/note_audio_player.dart';
 import 'package:parachute/core/widgets/note_links_section.dart';
+import 'package:parachute/core/widgets/note_metadata_section.dart';
 import 'package:parachute/core/widgets/wikilink_handler.dart';
 import 'package:parachute/core/widgets/wikilink_syntax.dart';
 import 'package:parachute/core/widgets/tag_picker.dart';
@@ -253,6 +254,10 @@ class _NoteDetailScreenState extends ConsumerState<NoteDetailScreen> {
           styleSheet: MarkdownStyleSheet.fromTheme(theme).copyWith(
             p: theme.textTheme.bodyLarge,
           ),
+        ),
+        NoteMetadataSection(
+          note: widget.note,
+          onChanged: widget.onChanged,
         ),
         NoteLinksSection(
           noteId: widget.note.id,

--- a/lib/core/services/graph_api_service.dart
+++ b/lib/core/services/graph_api_service.dart
@@ -95,15 +95,17 @@ class GraphApiService {
     return Note.fromJson(data as Map<String, dynamic>);
   }
 
-  /// Update a note's content and/or path.
+  /// Update a note's content, path, and/or metadata.
   Future<Note?> updateNote(
     String id, {
     String? content,
     String? path,
+    Map<String, dynamic>? metadata,
   }) async {
     final body = <String, dynamic>{};
     if (content != null) body['content'] = content;
     if (path != null) body['path'] = path;
+    if (metadata != null) body['metadata'] = metadata;
     final data = await _patch('/notes/$id', body);
     if (data == null) return null;
     return Note.fromJson(data as Map<String, dynamic>);

--- a/lib/core/widgets/note_metadata_section.dart
+++ b/lib/core/widgets/note_metadata_section.dart
@@ -1,0 +1,470 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:parachute/core/models/thing.dart';
+import 'package:parachute/core/theme/design_tokens.dart';
+import 'package:parachute/features/daily/journal/providers/journal_providers.dart';
+
+// ─── Tag schemas ──────────────────────────────────────────────────────────────
+// Hardcoded for now; can be made dynamic via GET /api/tag-schemas later.
+
+class _FieldDef {
+  final String key;
+  final String label;
+  final _FieldType type;
+  final List<String>? options; // for dropdown type
+
+  const _FieldDef(this.key, this.label, this.type, [this.options]);
+}
+
+enum _FieldType { text, dropdown, toggle }
+
+const _tagSchemas = <String, List<_FieldDef>>{
+  'person': [
+    _FieldDef('first_appeared', 'First appeared', _FieldType.text),
+    _FieldDef('relationship', 'Relationship', _FieldType.text),
+  ],
+  'project': [
+    _FieldDef('status', 'Status', _FieldType.dropdown,
+        ['idea', 'active', 'paused', 'completed', 'abandoned']),
+    _FieldDef('started', 'Started', _FieldType.text),
+  ],
+  'thread': [
+    _FieldDef('first_appeared', 'First appeared', _FieldType.text),
+    _FieldDef('active', 'Active', _FieldType.toggle),
+  ],
+  'event': [
+    _FieldDef('date', 'Date', _FieldType.text),
+  ],
+};
+
+/// Internal/system metadata keys to hide from the UI.
+const _hiddenKeys = {
+  'audio_rendered_at',
+  'audio_pending_at',
+  'transcript_pending_at',
+  'transcript_rendered_at',
+  'audio_url',
+  'type', // shown structurally via tag, not as raw field
+};
+
+// ─── Widget ───────────────────────────────────────────────────────────────────
+
+/// Displays note metadata as structured fields (schema-aware) or raw key-value
+/// pairs, with inline editing.
+class NoteMetadataSection extends ConsumerStatefulWidget {
+  final Note note;
+  final VoidCallback? onChanged;
+
+  const NoteMetadataSection({super.key, required this.note, this.onChanged});
+
+  @override
+  ConsumerState<NoteMetadataSection> createState() => _NoteMetadataSectionState();
+}
+
+class _NoteMetadataSectionState extends ConsumerState<NoteMetadataSection> {
+  late Map<String, dynamic> _metadata;
+  bool _saving = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _metadata = Map<String, dynamic>.from(widget.note.metadata);
+  }
+
+  /// Find the schema that applies to this note (first matching tag).
+  List<_FieldDef>? get _schema {
+    for (final tag in widget.note.tags) {
+      if (_tagSchemas.containsKey(tag)) return _tagSchemas[tag];
+    }
+    return null;
+  }
+
+  /// Keys already covered by the schema.
+  Set<String> get _schemaKeys =>
+      _schema?.map((f) => f.key).toSet() ?? const {};
+
+  /// Extra metadata keys not covered by schema and not hidden.
+  List<String> get _extraKeys {
+    final covered = _schemaKeys;
+    return _metadata.keys
+        .where((k) => !covered.contains(k) && !_hiddenKeys.contains(k))
+        .toList()
+      ..sort();
+  }
+
+  bool get _hasVisibleContent {
+    if (_schema != null) return true;
+    return _extraKeys.isNotEmpty;
+  }
+
+  Future<void> _saveMetadata(Map<String, dynamic> updated) async {
+    if (_saving) return;
+    setState(() => _saving = true);
+
+    final api = ref.read(graphApiServiceProvider);
+    final result = await api.updateNote(widget.note.id, metadata: updated);
+
+    if (!mounted) return;
+    setState(() => _saving = false);
+
+    if (result != null) {
+      _metadata = Map<String, dynamic>.from(updated);
+      widget.onChanged?.call();
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Failed to save — check connection')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_hasVisibleContent) return const SizedBox.shrink();
+
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+    final schema = _schema;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const SizedBox(height: 8),
+        const Divider(),
+        const SizedBox(height: 8),
+        // Schema fields (structured)
+        if (schema != null)
+          ...schema.map((field) => _buildSchemaField(theme, isDark, field)),
+        // Extra non-schema fields
+        ..._extraKeys.map((key) => _buildRawField(theme, isDark, key)),
+        if (_saving)
+          const Padding(
+            padding: EdgeInsets.only(top: 8),
+            child: SizedBox(
+              width: 16, height: 16,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            ),
+          ),
+      ],
+    );
+  }
+
+  Widget _buildSchemaField(ThemeData theme, bool isDark, _FieldDef field) {
+    final value = _metadata[field.key];
+
+    switch (field.type) {
+      case _FieldType.dropdown:
+        return _DropdownField(
+          label: field.label,
+          value: value?.toString() ?? '',
+          options: field.options!,
+          isDark: isDark,
+          onChanged: (newVal) {
+            final updated = Map<String, dynamic>.from(_metadata);
+            updated[field.key] = newVal;
+            _saveMetadata(updated);
+          },
+        );
+      case _FieldType.toggle:
+        final boolVal = value == true || value == 'true';
+        return _ToggleField(
+          label: field.label,
+          value: boolVal,
+          isDark: isDark,
+          onChanged: (newVal) {
+            final updated = Map<String, dynamic>.from(_metadata);
+            updated[field.key] = newVal;
+            _saveMetadata(updated);
+          },
+        );
+      case _FieldType.text:
+        return _TextField(
+          label: field.label,
+          value: value?.toString() ?? '',
+          placeholder: 'Add ${field.label.toLowerCase()}...',
+          isDark: isDark,
+          onSaved: (newVal) {
+            final updated = Map<String, dynamic>.from(_metadata);
+            updated[field.key] = newVal;
+            _saveMetadata(updated);
+          },
+        );
+    }
+  }
+
+  Widget _buildRawField(ThemeData theme, bool isDark, String key) {
+    final value = _metadata[key];
+    final label = _formatKey(key);
+    return _TextField(
+      label: label,
+      value: value?.toString() ?? '',
+      placeholder: 'Add value...',
+      isDark: isDark,
+      onSaved: (newVal) {
+        final updated = Map<String, dynamic>.from(_metadata);
+        updated[key] = newVal;
+        _saveMetadata(updated);
+      },
+    );
+  }
+
+  String _formatKey(String key) {
+    return key
+        .replaceAll('_', ' ')
+        .replaceFirst(key[0], key[0].toUpperCase());
+  }
+}
+
+// ─── Field widgets ────────────────────────────────────────────────────────────
+
+class _TextField extends StatefulWidget {
+  final String label;
+  final String value;
+  final String placeholder;
+  final bool isDark;
+  final void Function(String) onSaved;
+
+  const _TextField({
+    required this.label,
+    required this.value,
+    required this.placeholder,
+    required this.isDark,
+    required this.onSaved,
+  });
+
+  @override
+  State<_TextField> createState() => _TextFieldState();
+}
+
+class _TextFieldState extends State<_TextField> {
+  bool _editing = false;
+  late TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: widget.value);
+  }
+
+  @override
+  void didUpdateWidget(_TextField old) {
+    super.didUpdateWidget(old);
+    if (!_editing && old.value != widget.value) {
+      _controller.text = widget.value;
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _save() {
+    final trimmed = _controller.text.trim();
+    setState(() => _editing = false);
+    if (trimmed != widget.value) {
+      widget.onSaved(trimmed);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final labelColor = widget.isDark
+        ? BrandColors.nightTextSecondary
+        : BrandColors.driftwood;
+    final valueColor = widget.isDark
+        ? BrandColors.nightText
+        : BrandColors.charcoal;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          SizedBox(
+            width: 120,
+            child: Text(
+              widget.label,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: labelColor,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ),
+          Expanded(
+            child: _editing
+                ? SizedBox(
+                    height: 32,
+                    child: TextField(
+                      controller: _controller,
+                      autofocus: true,
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        color: valueColor,
+                      ),
+                      decoration: const InputDecoration(
+                        isDense: true,
+                        contentPadding: EdgeInsets.symmetric(
+                            horizontal: 8, vertical: 6),
+                        border: OutlineInputBorder(),
+                      ),
+                      onSubmitted: (_) => _save(),
+                      onTapOutside: (_) => _save(),
+                    ),
+                  )
+                : GestureDetector(
+                    onTap: () => setState(() => _editing = true),
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(
+                          vertical: 6, horizontal: 8),
+                      child: Text(
+                        widget.value.isNotEmpty
+                            ? widget.value
+                            : widget.placeholder,
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          color: widget.value.isNotEmpty
+                              ? valueColor
+                              : labelColor.withValues(alpha: 0.6),
+                          fontStyle: widget.value.isEmpty
+                              ? FontStyle.italic
+                              : null,
+                        ),
+                      ),
+                    ),
+                  ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _DropdownField extends StatelessWidget {
+  final String label;
+  final String value;
+  final List<String> options;
+  final bool isDark;
+  final void Function(String) onChanged;
+
+  const _DropdownField({
+    required this.label,
+    required this.value,
+    required this.options,
+    required this.isDark,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final labelColor = isDark
+        ? BrandColors.nightTextSecondary
+        : BrandColors.driftwood;
+    final valueColor = isDark
+        ? BrandColors.nightText
+        : BrandColors.charcoal;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          SizedBox(
+            width: 120,
+            child: Text(
+              label,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: labelColor,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ),
+          Expanded(
+            child: SizedBox(
+              height: 32,
+              child: DropdownButtonFormField<String>(
+                initialValue: options.contains(value) ? value : null,
+                isDense: true,
+                decoration: const InputDecoration(
+                  isDense: true,
+                  contentPadding:
+                      EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+                  border: OutlineInputBorder(),
+                ),
+                hint: Text(
+                  'Select...',
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: labelColor.withValues(alpha: 0.6),
+                    fontStyle: FontStyle.italic,
+                  ),
+                ),
+                items: options
+                    .map((o) => DropdownMenuItem(
+                          value: o,
+                          child: Text(
+                            o,
+                            style: theme.textTheme.bodyMedium?.copyWith(
+                              color: valueColor,
+                            ),
+                          ),
+                        ))
+                    .toList(),
+                onChanged: (v) {
+                  if (v != null) onChanged(v);
+                },
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ToggleField extends StatelessWidget {
+  final String label;
+  final bool value;
+  final bool isDark;
+  final void Function(bool) onChanged;
+
+  const _ToggleField({
+    required this.label,
+    required this.value,
+    required this.isDark,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final labelColor = isDark
+        ? BrandColors.nightTextSecondary
+        : BrandColors.driftwood;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        children: [
+          SizedBox(
+            width: 120,
+            child: Text(
+              label,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: labelColor,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ),
+          SizedBox(
+            height: 28,
+            child: Switch.adaptive(
+              value: value,
+              activeTrackColor: BrandColors.forest,
+              onChanged: onChanged,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/core/widgets/note_metadata_section.dart
+++ b/lib/core/widgets/note_metadata_section.dart
@@ -71,6 +71,16 @@ class _NoteMetadataSectionState extends ConsumerState<NoteMetadataSection> {
     _metadata = Map<String, dynamic>.from(widget.note.metadata);
   }
 
+  @override
+  void didUpdateWidget(NoteMetadataSection old) {
+    super.didUpdateWidget(old);
+    // Sync from parent if the note changed (e.g., provider refresh) and
+    // we're not mid-save (which has its own optimistic update).
+    if (old.note.id != widget.note.id || (!_saving && old.note.metadata != widget.note.metadata)) {
+      _metadata = Map<String, dynamic>.from(widget.note.metadata);
+    }
+  }
+
   /// Find the schema that applies to this note (first matching tag).
   List<_FieldDef>? get _schema {
     for (final tag in widget.note.tags) {
@@ -208,9 +218,9 @@ class _NoteMetadataSectionState extends ConsumerState<NoteMetadataSection> {
   }
 
   String _formatKey(String key) {
-    return key
-        .replaceAll('_', ' ')
-        .replaceFirst(key[0], key[0].toUpperCase());
+    if (key.isEmpty) return key;
+    final spaced = key.replaceAll('_', ' ');
+    return spaced[0].toUpperCase() + spaced.substring(1);
   }
 }
 


### PR DESCRIPTION
## Summary

- **New `NoteMetadataSection` widget** — renders metadata fields below note content on the detail screen
- **Tag schema awareness** — structured fields for known tag types:
  - `person`: First appeared (text) + Relationship (text)
  - `project`: Status (dropdown: idea/active/paused/completed/abandoned) + Started (text)
  - `thread`: First appeared (text) + Active (toggle)
  - `event`: Date (text)
- **Raw key-value display** for non-schema metadata (editable text fields)
- **Hidden system keys**: `audio_rendered_at`, `audio_pending_at`, `transcript_pending_at`, etc.
- **Inline editing**: tap a value to edit, saves immediately via `PATCH /api/notes/:id` with updated metadata
- **Added `metadata` param** to `GraphApiService.updateNote`

### Design
- Label-value layout with 120px label column
- Dropdown for enumerated fields (Status)
- Toggle switch for boolean fields (Active)
- Placeholder text for empty fields ("Add relationship...")
- Divider separator between content and metadata

## Files changed

- `lib/core/widgets/note_metadata_section.dart` — new widget (470 lines)
- `lib/core/screens/note_detail_screen.dart` — integrate metadata section
- `lib/core/services/graph_api_service.dart` — add metadata param to updateNote

## Self-review findings (fixed)

- Added `didUpdateWidget` to sync metadata from parent on provider refresh
- Guarded `_formatKey` against empty strings
- Confirmed `initialValue` is correct for this Flutter version's `DropdownButtonFormField`

## Test plan

- [ ] Open a person note (e.g., People/Mickey) → see "First appeared" and "Relationship" fields with values
- [ ] Tap "Relationship" value → edit inline, press enter → saves, value updates
- [ ] Open a project note → see Status dropdown + Started field
- [ ] Change Status via dropdown → saves immediately
- [ ] Open a thread note → see Active toggle, tap it → saves
- [ ] Open a note with no metadata → no metadata section shown
- [ ] Open a note with system-only metadata (e.g., audio_rendered_at) → no metadata section shown
- [ ] Dark mode styling correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)