### PR TITLE
feat: wikilink UX — create-on-tap, disambiguation polish, nav depth

### DIFF
--- a/lib/core/screens/note_detail_screen.dart
+++ b/lib/core/screens/note_detail_screen.dart
@@ -248,6 +248,7 @@ class _NoteDetailScreenState extends ConsumerState<NoteDetailScreen> {
                 api: ref.read(graphApiServiceProvider),
                 target: target,
                 onChanged: widget.onChanged,
+                replaceCurrentRoute: true,
               ),
             ),
           },

--- a/lib/core/widgets/note_links_section.dart
+++ b/lib/core/widgets/note_links_section.dart
@@ -123,7 +123,7 @@ class _NoteLinksSectionState extends ConsumerState<NoteLinksSection> {
   }
 
   void _navigateToNote(Note note) {
-    Navigator.of(context).push(
+    Navigator.of(context).pushReplacement(
       MaterialPageRoute(
         builder: (_) => NoteDetailScreen(
           note: note,

--- a/lib/core/widgets/wikilink_handler.dart
+++ b/lib/core/widgets/wikilink_handler.dart
@@ -9,12 +9,16 @@ import 'package:parachute/core/theme/design_tokens.dart';
 /// Searches by path first (exact match), then falls back to content search.
 /// When multiple notes match with similar relevance, shows a disambiguation
 /// bottom sheet so the user can pick the right one.
-/// Shows a snackbar if no matching note is found.
+/// If no note is found, offers to create one with the target as its path.
+///
+/// Set [replaceCurrentRoute] to true when navigating from within a detail
+/// screen — this uses pushReplacement to avoid unbounded stack growth.
 Future<void> handleWikilinkTap({
   required BuildContext context,
   required GraphApiService api,
   required String target,
   VoidCallback? onChanged,
+  bool replaceCurrentRoute = false,
 }) async {
   // Search for the note by its path/title
   final results = await api.searchNotes(target, limit: 10);
@@ -27,14 +31,39 @@ Future<void> handleWikilinkTap({
     return;
   }
   if (results.isEmpty) {
-    if (context.mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text('Note not found: $target'),
-          duration: const Duration(seconds: 2),
-        ),
-      );
+    if (!context.mounted) return;
+    // Offer to create the note
+    final shouldCreate = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text('Create "$target"?'),
+        content: const Text('No matching note found. Create a new one?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text('Create'),
+          ),
+        ],
+      ),
+    );
+    if (shouldCreate != true || !context.mounted) return;
+
+    final created = await api.createNote('', path: target);
+    if (created == null) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Failed to create note — check connection')),
+        );
+      }
+      return;
     }
+    if (!context.mounted) return;
+    _navigateToNote(context, created, onChanged,
+        replace: replaceCurrentRoute);
     return;
   }
 
@@ -45,26 +74,36 @@ Future<void> handleWikilinkTap({
 
   // Single strong match → navigate directly
   if (ranked.length == 1 || _isClearWinner(ranked, target)) {
-    _navigateToNote(context, ranked.first, onChanged);
+    _navigateToNote(context, ranked.first, onChanged,
+        replace: replaceCurrentRoute);
     return;
   }
 
   // Multiple ambiguous matches → show picker
   final chosen = await _showDisambiguationSheet(context, target, ranked);
   if (chosen != null && context.mounted) {
-    _navigateToNote(context, chosen, onChanged);
+    _navigateToNote(context, chosen, onChanged,
+        replace: replaceCurrentRoute);
   }
 }
 
-void _navigateToNote(BuildContext context, Note note, VoidCallback? onChanged) {
-  Navigator.of(context).push(
-    MaterialPageRoute(
-      builder: (_) => NoteDetailScreen(
-        note: note,
-        onChanged: onChanged,
-      ),
+void _navigateToNote(
+  BuildContext context,
+  Note note,
+  VoidCallback? onChanged, {
+  bool replace = false,
+}) {
+  final route = MaterialPageRoute(
+    builder: (_) => NoteDetailScreen(
+      note: note,
+      onChanged: onChanged,
     ),
   );
+  if (replace) {
+    Navigator.of(context).pushReplacement(route);
+  } else {
+    Navigator.of(context).push(route);
+  }
 }
 
 /// Score how well a note matches a wikilink target.
@@ -138,9 +177,9 @@ Future<Note?> _showDisambiguationSheet(
               const SizedBox(height: 12),
               ...options.take(8).map((note) {
                 final path = note.path ?? '';
-                final display = path.isNotEmpty
-                    ? path
-                    : _snippetFromContent(note.content);
+                final snippet = _snippetFromContent(note.content);
+                final hasPath = path.isNotEmpty;
+                final tags = note.tags.where((t) => t != 'captured').take(3).toList();
 
                 return ListTile(
                   leading: Icon(
@@ -151,20 +190,39 @@ Future<Note?> _showDisambiguationSheet(
                     size: 20,
                   ),
                   title: Text(
-                    display,
+                    hasPath ? path : snippet,
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
                   ),
-                  subtitle: path.isNotEmpty && note.content.isNotEmpty
-                      ? Text(
-                          _snippetFromContent(note.content),
-                          maxLines: 1,
+                  subtitle: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      if (hasPath && note.content.isNotEmpty)
+                        Text(
+                          snippet,
+                          maxLines: 2,
                           overflow: TextOverflow.ellipsis,
                           style: theme.textTheme.bodySmall?.copyWith(
                             color: theme.colorScheme.outline,
                           ),
-                        )
-                      : null,
+                        ),
+                      if (tags.isNotEmpty)
+                        Padding(
+                          padding: const EdgeInsets.only(top: 2),
+                          child: Text(
+                            tags.map((t) => '#$t').join('  '),
+                            style: theme.textTheme.labelSmall?.copyWith(
+                              color: isDark
+                                  ? BrandColors.forest.withValues(alpha: 0.7)
+                                  : BrandColors.forest.withValues(alpha: 0.6),
+                            ),
+                          ),
+                        ),
+                    ],
+                  ),
                   onTap: () => Navigator.of(ctx).pop(note),
                 );
               }),

--- a/lib/features/daily/journal/screens/entry_detail_screen.dart
+++ b/lib/features/daily/journal/screens/entry_detail_screen.dart
@@ -477,6 +477,7 @@ class _EntryDetailScreenState extends ConsumerState<EntryDetailScreen> {
             context: context,
             api: ref.read(graphApiServiceProvider),
             target: target,
+            replaceCurrentRoute: true,
           ),
         ),
       },


### PR DESCRIPTION
## Summary
- **Create on tap**: Tapping a `[[wikilink]]` to a nonexistent note now shows a "Create?" dialog instead of a dead-end snackbar. Creates the note with the wikilink target as its path and navigates directly to it.
- **Disambiguation polish**: Bottom sheet shows paths in bold w600, content preview expanded to 2 lines, and non-captured tag chips below each option.
- **Navigation depth**: Wikilink hops and backlink/forward-link taps from detail screens use `pushReplacement` instead of `push`, preventing unbounded stack growth. Back button returns to the originating list screen, not through a chain of detail screens.

## Files changed
- `lib/core/widgets/wikilink_handler.dart` — create-on-tap flow, `replaceCurrentRoute` param, disambiguation styling
- `lib/core/screens/note_detail_screen.dart` — pass `replaceCurrentRoute: true`
- `lib/core/widgets/note_links_section.dart` — `pushReplacement` for backlink/forward-link navigation
- `lib/features/daily/journal/screens/entry_detail_screen.dart` — pass `replaceCurrentRoute: true`

## Test plan
- [ ] Tap a `[[wikilink]]` to a note that doesn't exist → see "Create?" dialog → confirm → new note created and opened
- [ ] Cancel the create dialog → no note created, stays on current screen
- [ ] Tap a `[[wikilink]]` with multiple matches → disambiguation sheet shows bold paths, 2-line content, tag chips
- [ ] Navigate wikilink → wikilink → back → returns to list screen (not intermediate detail)
- [ ] Tap backlink in "Mentioned in" section → replaces current detail screen
- [ ] Network error during create → shows failure snackbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)