### PR TITLE
refactor: remove /api/ingest dependency

### DIFF
--- a/lib/features/daily/journal/providers/journal_providers.dart
+++ b/lib/features/daily/journal/providers/journal_providers.dart
@@ -240,7 +240,7 @@ Future<void> _flushPendingOps(
     final pendingCreates = cache.getPendingCreates();
     for (final note in pendingCreates) {
       final audioPath = cache.getAudioPath(note.id);
-      // Voice notes with local audio: use ingest endpoint (atomic)
+      // Voice notes with local audio: upload then create note with attachment
       if (audioPath != null && audioPath.startsWith('/')) {
         final audioFile = File(audioPath);
         if (!await audioFile.exists()) {
@@ -248,20 +248,35 @@ Future<void> _flushPendingOps(
           continue;
         }
 
-        final serverNote = await api.ingestVoiceMemo(
-          audioFile: audioFile,
+        final serverPath = await api.uploadAudio(audioFile);
+        if (serverPath == null) {
+          debugPrint('[FlushOps] Audio upload pending for ${note.id}');
+          continue;
+        }
+
+        final tags = note.tags.isNotEmpty ? note.tags : ['captured'];
+        final serverNote = await api.createNote(
+          content: note.content,
+          tags: tags,
           createdAt: note.createdAt,
-          durationSeconds: 0, // Duration not stored in pending note
-          transcribe: note.content.isEmpty, // Transcribe if no content yet
         );
 
         if (serverNote != null) {
+          final ext = audioPath.split('.').last.toLowerCase();
+          final mime = switch (ext) {
+            'ogg' || 'opus' => 'audio/ogg',
+            'wav' => 'audio/wav',
+            'mp3' => 'audio/mpeg',
+            'm4a' || 'mp4' => 'audio/mp4',
+            _ => 'audio/ogg',
+          };
+          await api.addAttachment(serverNote.id, serverPath, mime);
           cache.removeNote(note.id);
           cache.putNotes([serverNote]);
           try { await audioFile.delete(); } catch (_) {}
-          debugPrint('[FlushOps] Ingested ${note.id} → ${serverNote.id}');
+          debugPrint('[FlushOps] Flushed voice ${note.id} → ${serverNote.id}');
         } else {
-          debugPrint('[FlushOps] Ingest pending for ${note.id}');
+          debugPrint('[FlushOps] Create pending for ${note.id}');
         }
         continue;
       }

--- a/lib/features/daily/journal/screens/journal_screen.dart
+++ b/lib/features/daily/journal/screens/journal_screen.dart
@@ -473,86 +473,21 @@ class _JournalScreenState extends ConsumerState<JournalScreen> with WidgetsBindi
 
   Future<void> _addVoiceEntry(String transcript, String localAudioPath, int duration, DateTime createdAt) async {
     debugPrint('[JournalScreen] Adding voice entry (createdAt: $createdAt)...');
-
-    // Try ingest endpoint first (single atomic request — preferred for beta)
-    final api = ref.read(dailyApiServiceProvider);
-    final mode = await ref.read(transcriptionModeProvider.future);
-    if (!mounted) return;
-
-    // For auto mode: synchronous cached read of the reachability probe.
-    // The probe is an optimization, not a gate — its only job is to let us
-    // skip an ingest attempt we already know will fail. The save path must
-    // never block on it. If the stream has already emitted (e.g. settings
-    // screen had the reachability chip open), we honor that; otherwise we
-    // default to `true` and let the ingest-failure fallback below run
-    // `_addVoiceEntryLocally`, which post-#79 enqueues on-device transcription
-    // via `postHocTranscriptionProvider`. Nothing is lost if the optimistic
-    // default is wrong. See parachute-daily#70 / #73 / #74.
-    final useServerTranscription = switch (mode) {
-      TranscriptionMode.local => false,
-      TranscriptionMode.server => true,
-      TranscriptionMode.auto =>
-        ref.read(transcriptionServiceReachableProvider).valueOrNull ?? true,
-    };
-    if (!mounted) return;
-
-    // Try ingest (handles upload + note creation + transcription atomically)
-    final ingestResult = await api.ingestVoiceMemo(
-      audioFile: File(localAudioPath),
-      createdAt: createdAt,
-      durationSeconds: duration,
-      transcribe: useServerTranscription,
-    );
-
-    if (ingestResult != null && mounted) {
-      debugPrint('[JournalScreen] Ingest succeeded: ${ingestResult.id}, content: ${ingestResult.content.length} chars');
-
-      // Force a full refresh from server — the note is there now.
-      // Don't use _appendEntryToCache because the sync ingest takes long enough
-      // that the journal state may have changed while we were waiting.
-      ref.invalidate(selectedJournalProvider);
-      ref.read(journalRefreshTriggerProvider.notifier).state++;
-
-      if (!useServerTranscription) {
-        // Server stored the audio with empty content (transcribe: false).
-        // Kick off on-device transcription via the post-hoc queue — it'll
-        // PATCH the entry with the transcript when complete and clean up
-        // the staged audio file. Fires for TranscriptionMode.local AND for
-        // auto-mode when the transcription service is unreachable.
-        // See parachute-daily#72.
-        debugPrint('[JournalScreen] Enqueuing on-device transcription for ${ingestResult.id}');
-        ref.read(postHocTranscriptionProvider.notifier).enqueue(
-          entryId: ingestResult.id,
-          audioPath: localAudioPath,
-          durationSeconds: duration,
-        );
-      } else {
-        // Server did the transcription atomically — safe to clean up now.
-        try { await File(localAudioPath).delete(); } catch (_) {}
-      }
-      return;
-    }
-
-    // Ingest failed — fall back to local flow. Thread through the mode flag
-    // so the fallback can also enqueue on-device transcription when needed.
-    debugPrint('[JournalScreen] Ingest failed, falling back to local');
     await _addVoiceEntryLocally(
       transcript,
       localAudioPath,
       duration,
       createdAt,
-      useServerTranscription: useServerTranscription,
     );
   }
 
-  /// Fallback local flow: upload audio asset, create entry, let on-device transcription handle it.
+  /// Upload audio asset, create entry, enqueue on-device transcription.
   Future<void> _addVoiceEntryLocally(
     String transcript,
     String localAudioPath,
     int duration,
-    DateTime createdAt, {
-    required bool useServerTranscription,
-  }) async {
+    DateTime createdAt,
+  ) async {
     final api = ref.read(dailyApiServiceProvider);
 
     // Try to upload audio to server first
@@ -574,7 +509,6 @@ class _JournalScreenState extends ConsumerState<JournalScreen> with WidgetsBindi
       if (!mounted) return;
 
       if (entry != null) {
-        // Both upload and entry creation succeeded
         await _appendEntryToCache(
           entry,
           content: transcript,
@@ -583,25 +517,13 @@ class _JournalScreenState extends ConsumerState<JournalScreen> with WidgetsBindi
           durationSeconds: duration,
         );
 
-        if (!useServerTranscription) {
-          // Vault server is reachable enough for ingest fallback to upload
-          // and create the entry, but the user wants on-device transcription
-          // (local mode) or the transcription service is unreachable (auto
-          // falling back). Enqueue post-hoc — it owns the staged file lifecycle.
-          // See parachute-daily#72.
-          debugPrint('[JournalScreen] Enqueuing on-device transcription for ${entry.id} (fallback path)');
-          ref.read(postHocTranscriptionProvider.notifier).enqueue(
-            entryId: entry.id,
-            audioPath: localAudioPath,
-            durationSeconds: duration,
-          );
-        } else {
-          try {
-            await File(localAudioPath).delete();
-          } catch (e) {
-            debugPrint('[JournalScreen] Failed to delete staged audio: $e');
-          }
-        }
+        // Enqueue on-device transcription — it owns the staged file lifecycle.
+        debugPrint('[JournalScreen] Enqueuing on-device transcription for ${entry.id}');
+        ref.read(postHocTranscriptionProvider.notifier).enqueue(
+          entryId: entry.id,
+          audioPath: localAudioPath,
+          durationSeconds: duration,
+        );
       } else {
         // Upload succeeded but entry creation failed — queue with server path so audio
         // is not re-uploaded, then clean up the local staged file.

--- a/lib/features/daily/journal/services/daily_api_service.dart
+++ b/lib/features/daily/journal/services/daily_api_service.dart
@@ -214,72 +214,7 @@ class DailyApiService {
   }
 
   // ===========================================================================
-  // Ingest (preferred for voice memos — single atomic request)
-  // ===========================================================================
-
-  /// Ingest a voice memo via the unified /api/ingest endpoint.
-  ///
-  /// Sends audio file, tags, metadata, and optionally requests server-side
-  /// transcription. Returns the created Note with transcript if available.
-  /// This replaces the multi-step upload→create→attach→transcribe flow.
-  Future<Note?> ingestVoiceMemo({
-    required File audioFile,
-    required DateTime createdAt,
-    required int durationSeconds,
-    bool transcribe = true,
-    String? deviceInfo,
-  }) async {
-    final uri = Uri.parse('$baseUrl$_apiPrefix/ingest');
-    debugPrint('[DailyApiService] POST $uri (ingest voice memo)');
-    try {
-      final request = http.MultipartRequest('POST', uri);
-      if (apiKey != null && apiKey!.isNotEmpty) {
-        request.headers['Authorization'] = 'Bearer $apiKey';
-      }
-
-      // Audio file
-      request.files.add(await http.MultipartFile.fromPath('file', audioFile.path));
-
-      // Fields
-      request.fields['created_at'] = createdAt.toIso8601String();
-      request.fields['tags'] = 'captured';
-      request.fields['transcribe'] = transcribe.toString();
-      if (transcribe) request.fields['sync'] = 'true';
-      request.fields['metadata'] = jsonEncode({
-        'source': 'voice-memo',
-        'duration_seconds': durationSeconds,
-        if (deviceInfo != null) 'device': deviceInfo,
-      });
-
-      final streamed = await request.send().timeout(
-        const Duration(seconds: 120), // Transcription can take a while
-      );
-
-      if (streamed.statusCode >= 200 && streamed.statusCode < 300) {
-        onReachabilityChanged?.call(true);
-        final body = await streamed.stream.bytesToString();
-        final data = jsonDecode(body) as Map<String, dynamic>;
-
-        // The response may have { note: {...}, attachment: {...}, transcription: {...} }
-        // or just the note directly
-        final noteJson = data.containsKey('note')
-            ? data['note'] as Map<String, dynamic>
-            : data;
-        return Note.fromJson(noteJson);
-      }
-
-      debugPrint('[DailyApiService] ingest ${streamed.statusCode}');
-      onReachabilityChanged?.call(true);
-      return null;
-    } catch (e) {
-      debugPrint('[DailyApiService] ingestVoiceMemo error: $e');
-      onReachabilityChanged?.call(false);
-      return null;
-    }
-  }
-
-  // ===========================================================================
-  // Audio & Voice (legacy — use ingestVoiceMemo for new recordings)
+  // Audio & Voice
   // ===========================================================================
 
   /// Upload an audio file to the server.

--- a/lib/features/daily/journal/widgets/journal_input_bar.dart
+++ b/lib/features/daily/journal/widgets/journal_input_bar.dart
@@ -302,10 +302,9 @@ class _JournalInputBarState extends ConsumerState<JournalInputBar>
       debugPrint('[JournalInputBar] Daily recording stopped, audio at: $audioPath');
 
       // Hand the recording off to the screen. JournalScreen's
-      // `_addVoiceEntry` handles ingest + on-device transcription enqueue
-      // (post-hoc) when the server isn't doing transcription itself. It
-      // has access to the entry id returned from ingest, which this widget
-      // does not.
+      // `_addVoiceEntry` handles upload + note creation + on-device
+      // transcription enqueue. It has access to the entry id, which
+      // this widget does not.
       if (widget.onVoiceRecorded != null) {
         await widget.onVoiceRecorded!('', audioPath, durationSeconds, createdAt);
       }

--- a/lib/features/daily/recorder/providers/post_hoc_transcription_provider.dart
+++ b/lib/features/daily/recorder/providers/post_hoc_transcription_provider.dart
@@ -235,7 +235,7 @@ class PostHocTranscriptionNotifier extends StateNotifier<PostHocTranscriptionSta
 
       // Mark job as failed — staged file will be cleaned up in the finally
       // block below. The server still has its own copy of the audio (stored
-      // at ingest/uploadAudio time before this job was enqueued), so manual
+      // at uploadAudio time before this job was enqueued), so manual
       // re-transcribe can pull it back if the user wants to retry.
       await _tracker.failJob(entryId);
 
@@ -270,7 +270,7 @@ class PostHocTranscriptionNotifier extends StateNotifier<PostHocTranscriptionSta
       _service = null;
 
       // Clean up the staged audio file regardless of outcome. Safe because
-      // the server has its own copy (ingest or uploadAudio stored it before
+      // the server has its own copy (uploadAudio stored it before
       // enqueue) — manual re-transcribe can pull the audio back from the
       // server if the user wants to retry after a permanent failure. Only
       // the crash-recovery path may leave files behind; `restartIncompleteJobs`


### PR DESCRIPTION
## Summary
- Remove `DailyApiService.ingestVoiceMemo()` and all ingest-first code paths
- Voice memos now exclusively use: `POST /api/storage/upload` → `POST /api/notes` → on-device transcription
- Flush ops (offline queue) updated to use upload+create+attach instead of ingest
- Net: **-167 lines, +38 lines** across 5 files

Vault is removing `/api/ingest` and vector embeddings for launch simplification. Daily's fallback path (upload + create) was already battle-tested — this just makes it the only path.

## Test plan
- [ ] Record a voice memo → uploads audio → creates note → on-device transcription runs
- [ ] Record while offline → entry queues → reconnect → flush ops upload and create successfully
- [ ] Verify no references to `/api/ingest` remain in codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)