### PR TITLE
fix: force UTC for bare timestamps, bust stale cache

### DIFF
--- a/lib/core/models/thing.dart
+++ b/lib/core/models/thing.dart
@@ -35,6 +35,24 @@ class Note {
 
   // ---- Serialization ----
 
+  /// Parse a timestamp string, treating bare (no Z, no offset) strings as UTC.
+  ///
+  /// The vault server stores timestamps without a Z suffix. Dart's
+  /// DateTime.tryParse treats those as local time, causing a timezone-offset
+  /// shift when the client later calls .toUtc(). Force UTC interpretation so
+  /// cached timestamps match the server's actual values.
+  static DateTime? _parseUtc(String? raw) {
+    if (raw == null) return null;
+    final parsed = DateTime.tryParse(raw);
+    if (parsed == null) return null;
+    if (!raw.endsWith('Z') && !raw.contains('+') && !raw.contains('-', 10)) {
+      return DateTime.utc(parsed.year, parsed.month, parsed.day,
+          parsed.hour, parsed.minute, parsed.second,
+          parsed.millisecond, parsed.microsecond);
+    }
+    return parsed;
+  }
+
   factory Note.fromJson(Map<String, dynamic> json) {
     final now = DateTime.now();
     final createdRaw = json['createdAt'] as String?;
@@ -43,8 +61,8 @@ class Note {
       id: json['id'] as String,
       content: json['content'] as String? ?? '',
       path: json['path'] as String?,
-      createdAt: (createdRaw != null ? DateTime.tryParse(createdRaw) : null) ?? now,
-      updatedAt: updatedRaw != null ? DateTime.tryParse(updatedRaw) : null,
+      createdAt: _parseUtc(createdRaw) ?? now,
+      updatedAt: _parseUtc(updatedRaw),
       metadata: (json['metadata'] as Map<String, dynamic>?) ?? const {},
       tags: (json['tags'] as List<dynamic>?)
               ?.map((t) => t as String)

--- a/lib/core/services/note_local_cache.dart
+++ b/lib/core/services/note_local_cache.dart
@@ -19,6 +19,12 @@ import '../models/thing.dart';
 class NoteLocalCache {
   final Database _db;
 
+  /// Bump this when the schema changes or cached data must be invalidated.
+  /// On version mismatch the tables are dropped and recreated — the server
+  /// is the source of truth, so losing the cache is safe (pending ops may be
+  /// lost, but that's preferable to stale data that never self-heals).
+  static const _schemaVersion = 2; // v2: fix stale pending_create + timestamp shift
+
   NoteLocalCache._(this._db);
 
   /// Open (or create) the cache database in the app documents directory.
@@ -41,6 +47,18 @@ class NoteLocalCache {
   }
 
   void _ensureSchema() {
+    // Check stored schema version — drop and recreate on mismatch.
+    _db.execute('CREATE TABLE IF NOT EXISTS _meta (key TEXT PRIMARY KEY, value TEXT)');
+    final rows = _db.select("SELECT value FROM _meta WHERE key = 'schema_version'");
+    final stored = rows.isNotEmpty ? int.tryParse(rows.first['value'] as String? ?? '') ?? 0 : 0;
+
+    if (stored != _schemaVersion) {
+      debugPrint('[NoteLocalCache] schema version $stored → $_schemaVersion — resetting cache');
+      _db.execute('DROP TABLE IF EXISTS attachments');
+      _db.execute('DROP TABLE IF EXISTS notes');
+      _db.execute("INSERT OR REPLACE INTO _meta (key, value) VALUES ('schema_version', '$_schemaVersion')");
+    }
+
     _db.execute('''
       CREATE TABLE IF NOT EXISTS notes (
         id          TEXT PRIMARY KEY,


### PR DESCRIPTION
## Summary
- **Fix 1**: `Note.fromJson` — timestamps without Z suffix from the vault server were parsed as local time by Dart's `DateTime.tryParse`, causing a +6h shift when stored in cache via `.toUtc()`. New `_parseUtc()` helper forces UTC interpretation for bare timestamps.
- **Fix 2**: `NoteLocalCache` — add schema versioning. On version mismatch (v1→v2), notes and attachments tables are dropped and recreated, clearing stale `pending_create` entries that held empty content and resisted server overwrites via the ON CONFLICT guard.

Fixes the Apr 9-10 bug where notes displayed empty content and the same audio attachment despite the server having correct data.

## Test plan
- [ ] Install on device — cache should reset on first launch (check logcat for "schema version 0 → 2 — resetting cache")
- [ ] Navigate to Apr 9-10 — notes should show full content and unique audio per entry
- [ ] Verify Apr 8 and today still work correctly
- [ ] Create a new voice note — verify it records, transcribes, and displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)