### PR TITLE
fix: request full content from vault list endpoint

### DIFF
--- a/lib/core/services/graph_api_service.dart
+++ b/lib/core/services/graph_api_service.dart
@@ -64,6 +64,7 @@ class GraphApiService {
     if (dateTo != null) params['date_to'] = dateTo;
     if (sort != null) params['sort'] = sort;
     if (limit != null) params['limit'] = limit.toString();
+    params['include_content'] = 'true';
 
     final data = await _get('/notes', params);
     if (data == null) return null;

--- a/lib/features/daily/journal/services/daily_api_service.dart
+++ b/lib/features/daily/journal/services/daily_api_service.dart
@@ -98,6 +98,7 @@ class DailyApiService {
         'date_from': localFrom.toUtc().toIso8601String(),
         'date_to': localTo.toUtc().toIso8601String(),
         'limit': '100',
+        'include_content': 'true',
       },
     );
     debugPrint('[DailyApiService] GET $uri');


### PR DESCRIPTION
## Summary
- Vault's `GET /notes` defaults to lean index (no content). Daily wasn't passing `include_content=true`.
- After PR #97 busted the stale cache, fresh server responses had no content → empty notes.
- Added `include_content=true` to `DailyApiService.getNotes` and `GraphApiService.queryNotes`.

## Test plan
- [x] Deployed to device — verify Apr 9-10 notes show full content
- [ ] Verify Reader tab notes also show content
- [ ] Verify search results still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)