### PR TITLE
feat: Daily calls Scribe directly for voice memo transcription

### DIFF
--- a/lib/core/providers/backend_health_provider.dart
+++ b/lib/core/providers/backend_health_provider.dart
@@ -2,10 +2,12 @@ import 'dart:async';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../services/backend_health_service.dart';
 import '../services/transcription_api_service.dart';
+import '../services/tts_api_service.dart';
 import 'app_state_provider.dart' show apiKeyProvider;
 import 'feature_flags_provider.dart';
 import '../../features/daily/recorder/providers/service_providers.dart'
-    show transcriptionServiceUrlProvider, transcriptionServiceApiKeyProvider;
+    show transcriptionServiceUrlProvider, transcriptionServiceApiKeyProvider,
+         ttsServiceUrlProvider, ttsServiceApiKeyProvider;
 
 /// Provider for backend health service
 final backendHealthServiceProvider = Provider.family<BackendHealthService, String>((ref, baseUrl) {
@@ -96,6 +98,30 @@ final transcriptionApiServiceProvider = Provider<TranscriptionApiService?>((ref)
 
   final vaultApiKey = ref.watch(apiKeyProvider).valueOrNull;
   final service = TranscriptionApiService(baseUrl: vaultUrl, apiKey: vaultApiKey);
+  ref.onDispose(() => service.dispose());
+  return service;
+});
+
+/// Provider for a TtsApiService instance built from current settings.
+///
+/// Uses the custom TTS URL if configured, otherwise falls back to
+/// the vault server URL (vault can proxy to narrate).
+final ttsApiServiceProvider = Provider<TtsApiService?>((ref) {
+  // Try custom TTS URL first
+  final customUrl = ref.watch(ttsServiceUrlProvider).valueOrNull;
+  if (customUrl != null && customUrl.isNotEmpty) {
+    final apiKey = ref.watch(ttsServiceApiKeyProvider).valueOrNull;
+    final service = TtsApiService(baseUrl: customUrl, apiKey: apiKey);
+    ref.onDispose(() => service.dispose());
+    return service;
+  }
+
+  // Fall back to vault URL
+  final vaultUrl = ref.watch(aiServerUrlProvider).valueOrNull;
+  if (vaultUrl == null || vaultUrl.isEmpty) return null;
+
+  final vaultApiKey = ref.watch(apiKeyProvider).valueOrNull;
+  final service = TtsApiService(baseUrl: vaultUrl, apiKey: vaultApiKey);
   ref.onDispose(() => service.dispose());
   return service;
 });

--- a/lib/core/providers/backend_health_provider.dart
+++ b/lib/core/providers/backend_health_provider.dart
@@ -9,9 +9,11 @@ import '../../features/daily/recorder/providers/service_providers.dart'
     show transcriptionServiceUrlProvider, transcriptionServiceApiKeyProvider,
          ttsServiceUrlProvider, ttsServiceApiKeyProvider;
 
-/// Provider for backend health service
-final backendHealthServiceProvider = Provider.family<BackendHealthService, String>((ref, baseUrl) {
-  final service = BackendHealthService(baseUrl: baseUrl);
+/// Provider for backend health service (includes API key for authenticated endpoints)
+final backendHealthServiceProvider = Provider<BackendHealthService>((ref) {
+  final url = ref.watch(aiServerUrlProvider).valueOrNull ?? '';
+  final key = ref.watch(apiKeyProvider).valueOrNull;
+  final service = BackendHealthService(baseUrl: url, apiKey: key);
   ref.onDispose(() => service.dispose());
   return service;
 });
@@ -25,7 +27,7 @@ final serverHealthProvider = FutureProvider<ServerHealthStatus?>((ref) async {
     return null; // No server configured
   }
 
-  final service = ref.watch(backendHealthServiceProvider(url));
+  final service = ref.watch(backendHealthServiceProvider);
   return service.checkHealth();
 });
 
@@ -39,7 +41,7 @@ final periodicServerHealthProvider = StreamProvider<ServerHealthStatus?>((ref) a
     return;
   }
 
-  final service = ref.watch(backendHealthServiceProvider(url));
+  final service = ref.watch(backendHealthServiceProvider);
 
   // Initial check
   yield await service.checkHealth();

--- a/lib/core/screens/note_detail_screen.dart
+++ b/lib/core/screens/note_detail_screen.dart
@@ -7,6 +7,7 @@ import 'package:parachute/core/theme/design_tokens.dart';
 import 'package:parachute/core/widgets/note_audio_player.dart';
 import 'package:parachute/core/widgets/note_links_section.dart';
 import 'package:parachute/core/widgets/note_metadata_section.dart';
+import 'package:parachute/core/widgets/read_aloud_button.dart';
 import 'package:parachute/core/widgets/wikilink_handler.dart';
 import 'package:parachute/core/widgets/wikilink_syntax.dart';
 import 'package:parachute/core/widgets/tag_picker.dart';
@@ -192,7 +193,9 @@ class _NoteDetailScreenState extends ConsumerState<NoteDetailScreen> {
                     ? const SizedBox(width: 16, height: 16, child: CircularProgressIndicator(strokeWidth: 2))
                     : const Text('Save'),
               )
-            else
+            else ...[
+              if (_note.content.isNotEmpty)
+                ReadAloudButton(text: _note.content),
               IconButton(
                 icon: const Icon(Icons.edit_outlined),
                 onPressed: () => setState(() {
@@ -202,6 +205,7 @@ class _NoteDetailScreenState extends ConsumerState<NoteDetailScreen> {
                   });
                 }),
               ),
+            ],
           ],
         ),
         body: _isEditing ? _buildEditor(theme) : _buildReader(theme),

--- a/lib/core/screens/note_detail_screen.dart
+++ b/lib/core/screens/note_detail_screen.dart
@@ -195,7 +195,7 @@ class _NoteDetailScreenState extends ConsumerState<NoteDetailScreen> {
               )
             else ...[
               if (_note.content.isNotEmpty)
-                ReadAloudButton(text: _note.content),
+                ReadAloudButton(text: _note.content, noteId: _note.id),
               IconButton(
                 icon: const Icon(Icons.edit_outlined),
                 onPressed: () => setState(() {

--- a/lib/core/services/backend_health_service.dart
+++ b/lib/core/services/backend_health_service.dart
@@ -80,14 +80,21 @@ class ServerHealthStatus {
 /// Backend health checking service
 class BackendHealthService {
   final String baseUrl;
+  final String? apiKey;
   final Duration timeout;
   final http.Client _client;
 
   BackendHealthService({
     required this.baseUrl,
+    this.apiKey,
     this.timeout = const Duration(seconds: 3),
     http.Client? client,
   }) : _client = client ?? http.Client();
+
+  Map<String, String> get _authHeaders => {
+    if (apiKey != null && apiKey!.isNotEmpty)
+      'Authorization': 'Bearer $apiKey',
+  };
 
   /// Check server health
   Future<ServerHealthStatus> checkHealth() async {
@@ -102,7 +109,7 @@ class BackendHealthService {
 
     try {
       final uri = Uri.parse('$baseUrl/api/health');
-      final response = await _client.get(uri).timeout(timeout);
+      final response = await _client.get(uri, headers: _authHeaders).timeout(timeout);
 
       if (response.statusCode == 200) {
         String? version;

--- a/lib/core/services/transcription_api_service.dart
+++ b/lib/core/services/transcription_api_service.dart
@@ -71,27 +71,65 @@ class TranscriptionApiService {
   }
 
   /// Check if the transcription endpoint is reachable.
-  /// Returns a [ConnectionResult] with status and message.
+  ///
+  /// Tries multiple approaches since different services expose different
+  /// health endpoints:
+  /// 1. GET /health (common for self-hosted services like parachute-scribe)
+  /// 2. GET /v1/models (OpenAI-compatible services like Groq)
+  /// 3. HEAD on the base URL (fallback reachability check)
   Future<ConnectionResult> checkConnection() async {
+    final headers = <String, String>{
+      if (apiKey != null && apiKey!.isNotEmpty)
+        'Authorization': 'Bearer $apiKey',
+    };
+    const timeout = Duration(seconds: 5);
+
     try {
-      final uri = Uri.parse('$baseUrl/v1/models');
-      final request = http.Request('GET', uri);
-      if (apiKey != null && apiKey!.isNotEmpty) {
-        request.headers['Authorization'] = 'Bearer $apiKey';
+      // Try /health first (parachute-scribe, whisper.cpp server)
+      try {
+        final healthUri = Uri.parse('$baseUrl/health');
+        final healthResp = await _client
+            .get(healthUri, headers: headers)
+            .timeout(timeout);
+        if (healthResp.statusCode == 200) {
+          return ConnectionResult.ok('Transcription service connected');
+        }
+        if (healthResp.statusCode == 401 || healthResp.statusCode == 403) {
+          return ConnectionResult.authError(
+            'Server reachable but authentication failed — check your API key',
+          );
+        }
+      } catch (_) {
+        // /health not available, try next
       }
 
-      final streamedResponse = await _client.send(request).timeout(
-        const Duration(seconds: 5),
-      );
-      final response = await http.Response.fromStream(streamedResponse);
-
-      if (response.statusCode == 200) {
-        return ConnectionResult.ok('Transcription service connected');
-      } else if (response.statusCode == 401 || response.statusCode == 403) {
-        return ConnectionResult.authError('Server reachable but authentication failed — check your API key');
-      } else {
-        return ConnectionResult.error('Server returned ${response.statusCode}');
+      // Try /v1/models (OpenAI, Groq)
+      try {
+        final modelsUri = Uri.parse('$baseUrl/v1/models');
+        final modelsResp = await _client
+            .get(modelsUri, headers: headers)
+            .timeout(timeout);
+        if (modelsResp.statusCode == 200) {
+          return ConnectionResult.ok('Transcription service connected');
+        }
+        if (modelsResp.statusCode == 401 || modelsResp.statusCode == 403) {
+          return ConnectionResult.authError(
+            'Server reachable but authentication failed — check your API key',
+          );
+        }
+      } catch (_) {
+        // /v1/models not available, try next
       }
+
+      // Fallback: HEAD on base URL
+      final baseUri = Uri.parse(baseUrl);
+      final headReq = http.Request('HEAD', baseUri);
+      headReq.headers.addAll(headers);
+      final headResp = await _client.send(headReq).timeout(timeout);
+      if (headResp.statusCode < 500) {
+        return ConnectionResult.ok('Transcription service reachable');
+      }
+      return ConnectionResult.error('Server returned ${headResp.statusCode}');
     } catch (e) {
       debugPrint('[TranscriptionApi] Connection check failed: $e');
       return ConnectionResult.error('Could not reach transcription service');

--- a/lib/core/services/transcription_api_service.dart
+++ b/lib/core/services/transcription_api_service.dart
@@ -70,66 +70,27 @@ class TranscriptionApiService {
     return text.trim();
   }
 
-  /// Check if the transcription endpoint is reachable.
-  ///
-  /// Tries multiple approaches since different services expose different
-  /// health endpoints:
-  /// 1. GET /health (common for self-hosted services like parachute-scribe)
-  /// 2. GET /v1/models (OpenAI-compatible services like Groq)
-  /// 3. HEAD on the base URL (fallback reachability check)
+  /// Check if the transcription endpoint is reachable via GET /v1/models.
   Future<ConnectionResult> checkConnection() async {
-    final headers = <String, String>{
-      if (apiKey != null && apiKey!.isNotEmpty)
-        'Authorization': 'Bearer $apiKey',
-    };
-    const timeout = Duration(seconds: 5);
-
     try {
-      // Try /health first (parachute-scribe, whisper.cpp server)
-      try {
-        final healthUri = Uri.parse('$baseUrl/health');
-        final healthResp = await _client
-            .get(healthUri, headers: headers)
-            .timeout(timeout);
-        if (healthResp.statusCode == 200) {
-          return ConnectionResult.ok('Transcription service connected');
-        }
-        if (healthResp.statusCode == 401 || healthResp.statusCode == 403) {
-          return ConnectionResult.authError(
-            'Server reachable but authentication failed — check your API key',
-          );
-        }
-      } catch (_) {
-        // /health not available, try next
-      }
+      final uri = Uri.parse('$baseUrl/v1/models');
+      final headers = <String, String>{
+        if (apiKey != null && apiKey!.isNotEmpty)
+          'Authorization': 'Bearer $apiKey',
+      };
+      final response = await _client
+          .get(uri, headers: headers)
+          .timeout(const Duration(seconds: 5));
 
-      // Try /v1/models (OpenAI, Groq)
-      try {
-        final modelsUri = Uri.parse('$baseUrl/v1/models');
-        final modelsResp = await _client
-            .get(modelsUri, headers: headers)
-            .timeout(timeout);
-        if (modelsResp.statusCode == 200) {
-          return ConnectionResult.ok('Transcription service connected');
-        }
-        if (modelsResp.statusCode == 401 || modelsResp.statusCode == 403) {
-          return ConnectionResult.authError(
-            'Server reachable but authentication failed — check your API key',
-          );
-        }
-      } catch (_) {
-        // /v1/models not available, try next
+      if (response.statusCode == 200) {
+        return ConnectionResult.ok('Transcription service connected');
+      } else if (response.statusCode == 401 || response.statusCode == 403) {
+        return ConnectionResult.authError(
+          'Server reachable but authentication failed — check your API key',
+        );
+      } else {
+        return ConnectionResult.error('Server returned ${response.statusCode}');
       }
-
-      // Fallback: HEAD on base URL
-      final baseUri = Uri.parse(baseUrl);
-      final headReq = http.Request('HEAD', baseUri);
-      headReq.headers.addAll(headers);
-      final headResp = await _client.send(headReq).timeout(timeout);
-      if (headResp.statusCode < 500) {
-        return ConnectionResult.ok('Transcription service reachable');
-      }
-      return ConnectionResult.error('Server returned ${headResp.statusCode}');
     } catch (e) {
       debugPrint('[TranscriptionApi] Connection check failed: $e');
       return ConnectionResult.error('Could not reach transcription service');

--- a/lib/core/services/tts_api_service.dart
+++ b/lib/core/services/tts_api_service.dart
@@ -50,18 +50,41 @@ class TtsApiService {
   }
 
   /// Check if the TTS endpoint is reachable.
+  ///
+  /// Tries multiple strategies since different services expose different
+  /// health endpoints:
+  /// 1. GET /health (parachute-narrate)
+  /// 2. GET /v1/models (OpenAI)
+  /// 3. HEAD on base URL (fallback)
   Future<bool> checkConnection() async {
-    try {
-      final uri = Uri.parse('$baseUrl/v1/models');
-      final headers = <String, String>{
-        if (apiKey != null && apiKey!.isNotEmpty)
-          'Authorization': 'Bearer $apiKey',
-      };
+    final headers = <String, String>{
+      if (apiKey != null && apiKey!.isNotEmpty)
+        'Authorization': 'Bearer $apiKey',
+    };
+    const timeout = Duration(seconds: 5);
 
-      final response = await _client.get(uri, headers: headers).timeout(
-        const Duration(seconds: 5),
-      );
-      return response.statusCode == 200;
+    try {
+      // Try /health first (parachute-narrate)
+      try {
+        final resp = await _client
+            .get(Uri.parse('$baseUrl/health'), headers: headers)
+            .timeout(timeout);
+        if (resp.statusCode == 200) return true;
+      } catch (_) {}
+
+      // Try /v1/models (OpenAI)
+      try {
+        final resp = await _client
+            .get(Uri.parse('$baseUrl/v1/models'), headers: headers)
+            .timeout(timeout);
+        if (resp.statusCode == 200) return true;
+      } catch (_) {}
+
+      // Fallback: HEAD on base URL
+      final req = http.Request('HEAD', Uri.parse(baseUrl));
+      req.headers.addAll(headers);
+      final resp = await _client.send(req).timeout(timeout);
+      return resp.statusCode < 500;
     } catch (e) {
       debugPrint('[TtsApi] Connection check failed: $e');
       return false;

--- a/lib/core/services/tts_api_service.dart
+++ b/lib/core/services/tts_api_service.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+import 'dart:convert';
+
+/// OpenAI TTS-compatible API client for Narrate.
+///
+/// Sends text to any endpoint that speaks the OpenAI TTS API shape:
+///   POST {baseUrl}/v1/audio/speech
+///   body: { "input": "...", "model": "...", "voice": "..." }
+///   response: audio bytes (OGG Opus)
+///
+/// Compatible with: OpenAI, Narrate (parachute-narrate).
+class TtsApiService {
+  final String baseUrl;
+  final String? apiKey;
+  final http.Client _client;
+  final Duration _timeout;
+
+  TtsApiService({
+    required this.baseUrl,
+    this.apiKey,
+    http.Client? client,
+    Duration timeout = const Duration(seconds: 60),
+  })  : _client = client ?? http.Client(),
+        _timeout = timeout;
+
+  /// Synthesize speech from text. Returns audio bytes (OGG Opus).
+  Future<Uint8List> synthesize(String text) async {
+    final uri = Uri.parse('$baseUrl/v1/audio/speech');
+    final headers = <String, String>{
+      'Content-Type': 'application/json',
+      if (apiKey != null && apiKey!.isNotEmpty)
+        'Authorization': 'Bearer $apiKey',
+    };
+
+    final response = await _client.post(
+      uri,
+      headers: headers,
+      body: jsonEncode({'input': text}),
+    ).timeout(_timeout);
+
+    if (response.statusCode != 200) {
+      debugPrint('[TtsApi] Error ${response.statusCode}: ${response.body}');
+      throw Exception(
+        'TTS failed (${response.statusCode}): ${response.reasonPhrase}',
+      );
+    }
+
+    return response.bodyBytes;
+  }
+
+  /// Check if the TTS endpoint is reachable.
+  Future<bool> checkConnection() async {
+    try {
+      final uri = Uri.parse('$baseUrl/v1/models');
+      final headers = <String, String>{
+        if (apiKey != null && apiKey!.isNotEmpty)
+          'Authorization': 'Bearer $apiKey',
+      };
+
+      final response = await _client.get(uri, headers: headers).timeout(
+        const Duration(seconds: 5),
+      );
+      return response.statusCode == 200;
+    } catch (e) {
+      debugPrint('[TtsApi] Connection check failed: $e');
+      return false;
+    }
+  }
+
+  void dispose() {
+    _client.close();
+  }
+}

--- a/lib/core/services/tts_api_service.dart
+++ b/lib/core/services/tts_api_service.dart
@@ -49,42 +49,18 @@ class TtsApiService {
     return response.bodyBytes;
   }
 
-  /// Check if the TTS endpoint is reachable.
-  ///
-  /// Tries multiple strategies since different services expose different
-  /// health endpoints:
-  /// 1. GET /health (parachute-narrate)
-  /// 2. GET /v1/models (OpenAI)
-  /// 3. HEAD on base URL (fallback)
+  /// Check if the TTS endpoint is reachable via GET /v1/models.
   Future<bool> checkConnection() async {
-    final headers = <String, String>{
-      if (apiKey != null && apiKey!.isNotEmpty)
-        'Authorization': 'Bearer $apiKey',
-    };
-    const timeout = Duration(seconds: 5);
-
     try {
-      // Try /health first (parachute-narrate)
-      try {
-        final resp = await _client
-            .get(Uri.parse('$baseUrl/health'), headers: headers)
-            .timeout(timeout);
-        if (resp.statusCode == 200) return true;
-      } catch (_) {}
-
-      // Try /v1/models (OpenAI)
-      try {
-        final resp = await _client
-            .get(Uri.parse('$baseUrl/v1/models'), headers: headers)
-            .timeout(timeout);
-        if (resp.statusCode == 200) return true;
-      } catch (_) {}
-
-      // Fallback: HEAD on base URL
-      final req = http.Request('HEAD', Uri.parse(baseUrl));
-      req.headers.addAll(headers);
-      final resp = await _client.send(req).timeout(timeout);
-      return resp.statusCode < 500;
+      final uri = Uri.parse('$baseUrl/v1/models');
+      final headers = <String, String>{
+        if (apiKey != null && apiKey!.isNotEmpty)
+          'Authorization': 'Bearer $apiKey',
+      };
+      final response = await _client
+          .get(uri, headers: headers)
+          .timeout(const Duration(seconds: 5));
+      return response.statusCode == 200;
     } catch (e) {
       debugPrint('[TtsApi] Connection check failed: $e');
       return false;

--- a/lib/core/services/tts_audio_cache.dart
+++ b/lib/core/services/tts_audio_cache.dart
@@ -1,0 +1,50 @@
+import 'dart:io';
+import 'dart:convert';
+import 'package:crypto/crypto.dart';
+import 'package:flutter/foundation.dart';
+import 'package:path_provider/path_provider.dart';
+
+/// File-based cache for TTS audio, keyed by note ID + content hash.
+///
+/// Audio files are stored in the app's persistent support directory under
+/// `tts_cache/`. If the note content changes, the hash changes and a fresh
+/// synthesis is required.
+class TtsAudioCache {
+  static const _cacheDir = 'tts_cache';
+
+  /// Returns the cached audio file path if it exists, or null.
+  Future<String?> get(String noteId, String content) async {
+    final path = await _filePath(noteId, content);
+    final file = File(path);
+    if (await file.exists()) {
+      return path;
+    }
+    return null;
+  }
+
+  /// Saves audio bytes to the cache and returns the file path.
+  Future<String> put(String noteId, String content, Uint8List bytes) async {
+    final path = await _filePath(noteId, content);
+    final file = File(path);
+    await file.parent.create(recursive: true);
+    await file.writeAsBytes(bytes);
+    debugPrint('[TtsCache] Cached ${bytes.length} bytes for note $noteId');
+    return path;
+  }
+
+  /// Build a deterministic file path: `<appSupport>/tts_cache/<noteId>_<hash>.ogg`
+  Future<String> _filePath(String noteId, String content) async {
+    final dir = await getApplicationSupportDirectory();
+    final hash = _contentHash(content);
+    // Sanitize noteId for filesystem safety
+    final safeId = noteId.replaceAll(RegExp(r'[^\w-]'), '_');
+    return '${dir.path}/$_cacheDir/${safeId}_$hash.ogg';
+  }
+
+  /// SHA-256 of the content, truncated to 12 hex chars.
+  static String _contentHash(String content) {
+    final bytes = utf8.encode(content);
+    final digest = sha256.convert(bytes);
+    return digest.toString().substring(0, 12);
+  }
+}

--- a/lib/core/widgets/read_aloud_button.dart
+++ b/lib/core/widgets/read_aloud_button.dart
@@ -1,0 +1,220 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:just_audio/just_audio.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:parachute/core/providers/backend_health_provider.dart'
+    show ttsApiServiceProvider;
+import 'package:parachute/core/theme/design_tokens.dart';
+
+/// Icon button that synthesizes speech via the TTS service and plays it.
+///
+/// Audio is ephemeral — written to a temp file, played, then deleted.
+/// Shows a loading spinner while synthesizing.
+class ReadAloudButton extends ConsumerStatefulWidget {
+  final String text;
+
+  const ReadAloudButton({super.key, required this.text});
+
+  @override
+  ConsumerState<ReadAloudButton> createState() => _ReadAloudButtonState();
+}
+
+enum _TtsPhase { idle, synthesizing, playing }
+
+class _ReadAloudButtonState extends ConsumerState<ReadAloudButton> {
+  _TtsPhase _phase = _TtsPhase.idle;
+  AudioPlayer? _player;
+  String? _tempPath;
+
+  @override
+  void dispose() {
+    _cleanup();
+    super.dispose();
+  }
+
+  Future<void> _cleanup() async {
+    await _player?.stop();
+    _player?.dispose();
+    _player = null;
+    if (_tempPath != null) {
+      try {
+        await File(_tempPath!).delete();
+      } catch (_) {}
+      _tempPath = null;
+    }
+  }
+
+  Future<void> _readAloud() async {
+    // If already playing, stop
+    if (_phase == _TtsPhase.playing) {
+      await _cleanup();
+      if (mounted) setState(() => _phase = _TtsPhase.idle);
+      return;
+    }
+
+    final ttsService = ref.read(ttsApiServiceProvider);
+    if (ttsService == null) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: const Text('TTS service not configured — check Settings'),
+            backgroundColor: BrandColors.warning,
+          ),
+        );
+      }
+      return;
+    }
+
+    setState(() => _phase = _TtsPhase.synthesizing);
+
+    try {
+      final bytes = await ttsService.synthesize(widget.text);
+
+      // Write to temp file
+      final dir = await getTemporaryDirectory();
+      final file = File('${dir.path}/tts_${DateTime.now().millisecondsSinceEpoch}.ogg');
+      await file.writeAsBytes(bytes);
+      _tempPath = file.path;
+
+      // Play
+      _player = AudioPlayer();
+      await _player!.setFilePath(file.path);
+
+      if (!mounted) {
+        await _cleanup();
+        return;
+      }
+      setState(() => _phase = _TtsPhase.playing);
+
+      _player!.playerStateStream.listen((state) {
+        if (state.processingState == ProcessingState.completed) {
+          _cleanup();
+          if (mounted) setState(() => _phase = _TtsPhase.idle);
+        }
+      });
+
+      await _player!.play();
+    } catch (e) {
+      debugPrint('[ReadAloud] TTS error: $e');
+      await _cleanup();
+      if (mounted) {
+        setState(() => _phase = _TtsPhase.idle);
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Read aloud failed: $e'),
+            backgroundColor: BrandColors.error,
+          ),
+        );
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ttsService = ref.watch(ttsApiServiceProvider);
+
+    // Don't show the button if TTS isn't configured
+    if (ttsService == null) return const SizedBox.shrink();
+
+    switch (_phase) {
+      case _TtsPhase.idle:
+        return IconButton(
+          icon: const Icon(Icons.volume_up_outlined),
+          onPressed: _readAloud,
+          tooltip: 'Read aloud',
+        );
+      case _TtsPhase.synthesizing:
+        return const SizedBox(
+          width: 48,
+          height: 48,
+          child: Center(
+            child: SizedBox(
+              width: 20,
+              height: 20,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            ),
+          ),
+        );
+      case _TtsPhase.playing:
+        return IconButton(
+          icon: const Icon(Icons.stop_circle_outlined),
+          onPressed: _readAloud,
+          tooltip: 'Stop',
+        );
+    }
+  }
+}
+
+/// Standalone function for triggering read-aloud from non-widget contexts
+/// (e.g., popup menu callbacks). Shows a snackbar with progress.
+Future<void> readAloudFromContext({
+  required BuildContext context,
+  required WidgetRef ref,
+  required String text,
+}) async {
+  final ttsService = ref.read(ttsApiServiceProvider);
+  if (ttsService == null) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: const Text('TTS service not configured — check Settings'),
+        backgroundColor: BrandColors.warning,
+      ),
+    );
+    return;
+  }
+
+  ScaffoldMessenger.of(context).showSnackBar(
+    SnackBar(
+      content: Row(
+        children: [
+          SizedBox(
+            width: 16,
+            height: 16,
+            child: CircularProgressIndicator(
+              strokeWidth: 2,
+              valueColor: AlwaysStoppedAnimation<Color>(BrandColors.softWhite),
+            ),
+          ),
+          const SizedBox(width: 12),
+          const Text('Synthesizing speech...'),
+        ],
+      ),
+      duration: const Duration(seconds: 30),
+    ),
+  );
+
+  try {
+    final bytes = await ttsService.synthesize(text);
+
+    final dir = await getTemporaryDirectory();
+    final file = File('${dir.path}/tts_${DateTime.now().millisecondsSinceEpoch}.ogg');
+    await file.writeAsBytes(bytes);
+
+    final player = AudioPlayer();
+    await player.setFilePath(file.path);
+
+    if (context.mounted) {
+      ScaffoldMessenger.of(context).clearSnackBars();
+    }
+
+    player.playerStateStream.listen((state) {
+      if (state.processingState == ProcessingState.completed) {
+        player.dispose();
+        file.delete().catchError((_) => file);
+      }
+    });
+
+    await player.play();
+  } catch (e) {
+    if (context.mounted) {
+      ScaffoldMessenger.of(context).clearSnackBars();
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Read aloud failed: $e'),
+          backgroundColor: BrandColors.error,
+        ),
+      );
+    }
+  }
+}

--- a/lib/core/widgets/read_aloud_button.dart
+++ b/lib/core/widgets/read_aloud_button.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -7,10 +8,13 @@ import 'package:parachute/core/providers/backend_health_provider.dart'
     show ttsApiServiceProvider;
 import 'package:parachute/core/theme/design_tokens.dart';
 
+enum _TtsPhase { idle, synthesizing, playing }
+
 /// Icon button that synthesizes speech via the TTS service and plays it.
 ///
-/// Audio is ephemeral — written to a temp file, played, then deleted.
-/// Shows a loading spinner while synthesizing.
+/// In idle state, renders as a simple icon button in the AppBar.
+/// When playing, shows a full inline player with pause/resume, scrubber,
+/// and time display below the trigger button area.
 class ReadAloudButton extends ConsumerStatefulWidget {
   final String text;
 
@@ -20,20 +24,37 @@ class ReadAloudButton extends ConsumerStatefulWidget {
   ConsumerState<ReadAloudButton> createState() => _ReadAloudButtonState();
 }
 
-enum _TtsPhase { idle, synthesizing, playing }
-
 class _ReadAloudButtonState extends ConsumerState<ReadAloudButton> {
   _TtsPhase _phase = _TtsPhase.idle;
   AudioPlayer? _player;
   String? _tempPath;
 
+  StreamSubscription<Duration>? _positionSub;
+  StreamSubscription<Duration?>? _durationSub;
+  StreamSubscription<PlayerState>? _stateSub;
+
+  Duration _position = Duration.zero;
+  Duration _duration = Duration.zero;
+  bool _playing = false;
+
   @override
   void dispose() {
+    _cancelSubs();
     _cleanup();
     super.dispose();
   }
 
+  void _cancelSubs() {
+    _positionSub?.cancel();
+    _durationSub?.cancel();
+    _stateSub?.cancel();
+    _positionSub = null;
+    _durationSub = null;
+    _stateSub = null;
+  }
+
   Future<void> _cleanup() async {
+    _cancelSubs();
     await _player?.stop();
     _player?.dispose();
     _player = null;
@@ -43,10 +64,15 @@ class _ReadAloudButtonState extends ConsumerState<ReadAloudButton> {
       } catch (_) {}
       _tempPath = null;
     }
+    _position = Duration.zero;
+    _duration = Duration.zero;
+    _playing = false;
   }
 
-  Future<void> _readAloud() async {
-    // If already playing, stop
+  Future<void> _synthesizeAndPlay() async {
+    if (_phase == _TtsPhase.synthesizing) return;
+
+    // If already playing, stop and reset
     if (_phase == _TtsPhase.playing) {
       await _cleanup();
       if (mounted) setState(() => _phase = _TtsPhase.idle);
@@ -71,13 +97,11 @@ class _ReadAloudButtonState extends ConsumerState<ReadAloudButton> {
     try {
       final bytes = await ttsService.synthesize(widget.text);
 
-      // Write to temp file
       final dir = await getTemporaryDirectory();
       final file = File('${dir.path}/tts_${DateTime.now().millisecondsSinceEpoch}.ogg');
       await file.writeAsBytes(bytes);
       _tempPath = file.path;
 
-      // Play
       _player = AudioPlayer();
       await _player!.setFilePath(file.path);
 
@@ -85,15 +109,25 @@ class _ReadAloudButtonState extends ConsumerState<ReadAloudButton> {
         await _cleanup();
         return;
       }
-      setState(() => _phase = _TtsPhase.playing);
 
-      _player!.playerStateStream.listen((state) {
-        if (state.processingState == ProcessingState.completed) {
-          _cleanup();
-          if (mounted) setState(() => _phase = _TtsPhase.idle);
+      // Wire up streams
+      _positionSub = _player!.positionStream.listen((p) {
+        if (mounted) setState(() => _position = p);
+      });
+      _durationSub = _player!.durationStream.listen((d) {
+        if (mounted && d != null) setState(() => _duration = d);
+      });
+      _stateSub = _player!.playerStateStream.listen((s) {
+        if (!mounted) return;
+        setState(() => _playing = s.playing);
+        if (s.processingState == ProcessingState.completed) {
+          _player!.pause();
+          _player!.seek(Duration.zero);
+          setState(() => _playing = false);
         }
       });
 
+      setState(() => _phase = _TtsPhase.playing);
       await _player!.play();
     } catch (e) {
       debugPrint('[ReadAloud] TTS error: $e');
@@ -110,18 +144,40 @@ class _ReadAloudButtonState extends ConsumerState<ReadAloudButton> {
     }
   }
 
+  Future<void> _togglePlayPause() async {
+    if (_player == null) return;
+    if (_playing) {
+      await _player!.pause();
+    } else {
+      await _player!.play();
+    }
+  }
+
+  Future<void> _seek(double ms) async {
+    await _player?.seek(Duration(milliseconds: ms.toInt()));
+  }
+
+  Future<void> _stop() async {
+    await _cleanup();
+    if (mounted) setState(() => _phase = _TtsPhase.idle);
+  }
+
+  String _fmt(Duration d) {
+    final m = d.inMinutes;
+    final s = d.inSeconds % 60;
+    return '${m.toString().padLeft(2, '0')}:${s.toString().padLeft(2, '0')}';
+  }
+
   @override
   Widget build(BuildContext context) {
     final ttsService = ref.watch(ttsApiServiceProvider);
-
-    // Don't show the button if TTS isn't configured
     if (ttsService == null) return const SizedBox.shrink();
 
     switch (_phase) {
       case _TtsPhase.idle:
         return IconButton(
           icon: const Icon(Icons.volume_up_outlined),
-          onPressed: _readAloud,
+          onPressed: _synthesizeAndPlay,
           tooltip: 'Read aloud',
         );
       case _TtsPhase.synthesizing:
@@ -137,17 +193,97 @@ class _ReadAloudButtonState extends ConsumerState<ReadAloudButton> {
           ),
         );
       case _TtsPhase.playing:
-        return IconButton(
-          icon: const Icon(Icons.stop_circle_outlined),
-          onPressed: _readAloud,
-          tooltip: 'Stop',
-        );
+        return _buildPlayer(context);
     }
+  }
+
+  Widget _buildPlayer(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final maxMs = _duration.inMilliseconds > 0
+        ? _duration.inMilliseconds.toDouble()
+        : 1.0;
+    final curMs = _position.inMilliseconds.toDouble().clamp(0.0, maxMs);
+
+    return SizedBox(
+      width: 220,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          // Play/pause
+          GestureDetector(
+            onTap: _togglePlayPause,
+            child: Icon(
+              _playing ? Icons.pause_circle_filled : Icons.play_circle_filled,
+              color: BrandColors.turquoise,
+              size: 28,
+            ),
+          ),
+          const SizedBox(width: 4),
+          // Time + scrubber
+          Expanded(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                SizedBox(
+                  height: 16,
+                  child: SliderTheme(
+                    data: SliderTheme.of(context).copyWith(
+                      trackHeight: 2,
+                      thumbShape: const RoundSliderThumbShape(enabledThumbRadius: 5),
+                      overlayShape: const RoundSliderOverlayShape(overlayRadius: 10),
+                      activeTrackColor: BrandColors.turquoise,
+                      inactiveTrackColor: BrandColors.turquoise.withValues(alpha: 0.2),
+                      thumbColor: BrandColors.turquoise,
+                    ),
+                    child: Slider(
+                      value: curMs,
+                      max: maxMs,
+                      onChanged: _duration.inMilliseconds > 0 ? _seek : null,
+                    ),
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 4),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Text(
+                        _fmt(_position),
+                        style: TextStyle(
+                          fontSize: 10,
+                          color: isDark ? BrandColors.nightTextSecondary : BrandColors.driftwood,
+                        ),
+                      ),
+                      Text(
+                        _fmt(_duration),
+                        style: TextStyle(
+                          fontSize: 10,
+                          color: isDark ? BrandColors.nightTextSecondary : BrandColors.driftwood,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+          // Stop/close
+          GestureDetector(
+            onTap: _stop,
+            child: Icon(
+              Icons.close,
+              color: isDark ? BrandColors.nightTextSecondary : BrandColors.driftwood,
+              size: 18,
+            ),
+          ),
+        ],
+      ),
+    );
   }
 }
 
 /// Standalone function for triggering read-aloud from non-widget contexts
-/// (e.g., popup menu callbacks). Shows a snackbar with progress.
+/// (e.g., popup menu callbacks). Shows a persistent player bar via SnackBar.
 Future<void> readAloudFromContext({
   required BuildContext context,
   required WidgetRef ref,
@@ -196,12 +332,23 @@ Future<void> readAloudFromContext({
 
     if (context.mounted) {
       ScaffoldMessenger.of(context).clearSnackBars();
+      // Show persistent player SnackBar
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: _SnackBarPlayer(player: player),
+          duration: const Duration(minutes: 30),
+          backgroundColor: Colors.transparent,
+          elevation: 0,
+          padding: EdgeInsets.zero,
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
     }
 
     player.playerStateStream.listen((state) {
       if (state.processingState == ProcessingState.completed) {
-        player.dispose();
-        file.delete().catchError((_) => file);
+        player.pause();
+        player.seek(Duration.zero);
       }
     });
 
@@ -216,5 +363,147 @@ Future<void> readAloudFromContext({
         ),
       );
     }
+  }
+}
+
+/// Stateful player widget embedded in a SnackBar for the long-press context.
+class _SnackBarPlayer extends StatefulWidget {
+  final AudioPlayer player;
+  const _SnackBarPlayer({required this.player});
+
+  @override
+  State<_SnackBarPlayer> createState() => _SnackBarPlayerState();
+}
+
+class _SnackBarPlayerState extends State<_SnackBarPlayer> {
+  StreamSubscription<Duration>? _posSub;
+  StreamSubscription<Duration?>? _durSub;
+  StreamSubscription<PlayerState>? _stateSub;
+
+  Duration _position = Duration.zero;
+  Duration _duration = Duration.zero;
+  bool _playing = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _posSub = widget.player.positionStream.listen((p) {
+      if (mounted) setState(() => _position = p);
+    });
+    _durSub = widget.player.durationStream.listen((d) {
+      if (mounted && d != null) setState(() => _duration = d);
+    });
+    _stateSub = widget.player.playerStateStream.listen((s) {
+      if (!mounted) return;
+      setState(() => _playing = s.playing);
+    });
+  }
+
+  @override
+  void dispose() {
+    _posSub?.cancel();
+    _durSub?.cancel();
+    _stateSub?.cancel();
+    widget.player.dispose();
+    super.dispose();
+  }
+
+  String _fmt(Duration d) {
+    final m = d.inMinutes;
+    final s = d.inSeconds % 60;
+    return '${m.toString().padLeft(2, '0')}:${s.toString().padLeft(2, '0')}';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final maxMs = _duration.inMilliseconds > 0
+        ? _duration.inMilliseconds.toDouble()
+        : 1.0;
+    final curMs = _position.inMilliseconds.toDouble().clamp(0.0, maxMs);
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      decoration: BoxDecoration(
+        color: BrandColors.nightSurfaceElevated,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(
+          color: BrandColors.turquoise.withValues(alpha: 0.4),
+        ),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Row(
+            children: [
+              GestureDetector(
+                onTap: () {
+                  if (_playing) {
+                    widget.player.pause();
+                  } else {
+                    widget.player.play();
+                  }
+                },
+                child: Icon(
+                  _playing ? Icons.pause_circle_filled : Icons.play_circle_filled,
+                  color: BrandColors.turquoise,
+                  size: 32,
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: SliderTheme(
+                  data: SliderTheme.of(context).copyWith(
+                    trackHeight: 3,
+                    thumbShape: const RoundSliderThumbShape(enabledThumbRadius: 6),
+                    overlayShape: const RoundSliderOverlayShape(overlayRadius: 12),
+                    activeTrackColor: BrandColors.turquoise,
+                    inactiveTrackColor: BrandColors.turquoise.withValues(alpha: 0.2),
+                    thumbColor: BrandColors.turquoise,
+                  ),
+                  child: Slider(
+                    value: curMs,
+                    max: maxMs,
+                    onChanged: _duration.inMilliseconds > 0
+                        ? (v) => widget.player.seek(Duration(milliseconds: v.toInt()))
+                        : null,
+                  ),
+                ),
+              ),
+              GestureDetector(
+                onTap: () {
+                  widget.player.stop();
+                  ScaffoldMessenger.of(context).clearSnackBars();
+                },
+                child: const Icon(
+                  Icons.close,
+                  color: BrandColors.driftwood,
+                  size: 20,
+                ),
+              ),
+            ],
+          ),
+          Padding(
+            padding: const EdgeInsets.only(left: 40, right: 28),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  _fmt(_position),
+                  style: const TextStyle(fontSize: 11, color: BrandColors.driftwood),
+                ),
+                const Text(
+                  'Read aloud',
+                  style: TextStyle(fontSize: 11, color: BrandColors.driftwood),
+                ),
+                Text(
+                  _fmt(_duration),
+                  style: const TextStyle(fontSize: 11, color: BrandColors.driftwood),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
   }
 }

--- a/lib/core/widgets/read_aloud_button.dart
+++ b/lib/core/widgets/read_aloud_button.dart
@@ -6,6 +6,7 @@ import 'package:just_audio/just_audio.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:parachute/core/providers/backend_health_provider.dart'
     show ttsApiServiceProvider;
+import 'package:parachute/core/services/tts_audio_cache.dart';
 import 'package:parachute/core/theme/design_tokens.dart';
 
 enum _TtsPhase { idle, synthesizing, playing }
@@ -17,8 +18,10 @@ enum _TtsPhase { idle, synthesizing, playing }
 /// and time display below the trigger button area.
 class ReadAloudButton extends ConsumerStatefulWidget {
   final String text;
+  /// When provided, audio is cached on device keyed by noteId + content hash.
+  final String? noteId;
 
-  const ReadAloudButton({super.key, required this.text});
+  const ReadAloudButton({super.key, required this.text, this.noteId});
 
   @override
   ConsumerState<ReadAloudButton> createState() => _ReadAloudButtonState();
@@ -28,6 +31,8 @@ class _ReadAloudButtonState extends ConsumerState<ReadAloudButton> {
   _TtsPhase _phase = _TtsPhase.idle;
   AudioPlayer? _player;
   String? _tempPath;
+  bool _isCached = false;
+  final _cache = TtsAudioCache();
 
   StreamSubscription<Duration>? _positionSub;
   StreamSubscription<Duration?>? _durationSub;
@@ -58,12 +63,14 @@ class _ReadAloudButtonState extends ConsumerState<ReadAloudButton> {
     await _player?.stop();
     _player?.dispose();
     _player = null;
-    if (_tempPath != null) {
+    // Only delete temp files, not cached ones
+    if (_tempPath != null && !_isCached) {
       try {
         await File(_tempPath!).delete();
       } catch (_) {}
-      _tempPath = null;
     }
+    _tempPath = null;
+    _isCached = false;
     _position = Duration.zero;
     _duration = Duration.zero;
     _playing = false;
@@ -95,15 +102,31 @@ class _ReadAloudButtonState extends ConsumerState<ReadAloudButton> {
     setState(() => _phase = _TtsPhase.synthesizing);
 
     try {
-      final bytes = await ttsService.synthesize(widget.text);
+      // Check cache first
+      String? filePath;
+      if (widget.noteId != null) {
+        filePath = await _cache.get(widget.noteId!, widget.text);
+      }
 
-      final dir = await getTemporaryDirectory();
-      final file = File('${dir.path}/tts_${DateTime.now().millisecondsSinceEpoch}.ogg');
-      await file.writeAsBytes(bytes);
-      _tempPath = file.path;
+      if (filePath != null) {
+        _isCached = true;
+        debugPrint('[ReadAloud] Cache hit for note ${widget.noteId}');
+      } else {
+        final bytes = await ttsService.synthesize(widget.text);
+        if (widget.noteId != null) {
+          filePath = await _cache.put(widget.noteId!, widget.text, bytes);
+          _isCached = true;
+        } else {
+          final dir = await getTemporaryDirectory();
+          final file = File('${dir.path}/tts_${DateTime.now().millisecondsSinceEpoch}.ogg');
+          await file.writeAsBytes(bytes);
+          filePath = file.path;
+        }
+      }
+      _tempPath = filePath;
 
       _player = AudioPlayer();
-      await _player!.setFilePath(file.path);
+      await _player!.setFilePath(filePath);
 
       if (!mounted) {
         await _cleanup();
@@ -284,10 +307,13 @@ class _ReadAloudButtonState extends ConsumerState<ReadAloudButton> {
 
 /// Standalone function for triggering read-aloud from non-widget contexts
 /// (e.g., popup menu callbacks). Shows a persistent player bar via SnackBar.
+///
+/// When [noteId] is provided, the audio is cached on device for instant replay.
 Future<void> readAloudFromContext({
   required BuildContext context,
   required WidgetRef ref,
   required String text,
+  String? noteId,
 }) async {
   final ttsService = ref.read(ttsApiServiceProvider);
   if (ttsService == null) {
@@ -321,14 +347,30 @@ Future<void> readAloudFromContext({
   );
 
   try {
-    final bytes = await ttsService.synthesize(text);
+    final cache = TtsAudioCache();
+    String? filePath;
 
-    final dir = await getTemporaryDirectory();
-    final file = File('${dir.path}/tts_${DateTime.now().millisecondsSinceEpoch}.ogg');
-    await file.writeAsBytes(bytes);
+    // Check cache first
+    if (noteId != null) {
+      filePath = await cache.get(noteId, text);
+    }
+
+    if (filePath != null) {
+      debugPrint('[ReadAloud] Cache hit for note $noteId');
+    } else {
+      final bytes = await ttsService.synthesize(text);
+      if (noteId != null) {
+        filePath = await cache.put(noteId, text, bytes);
+      } else {
+        final dir = await getTemporaryDirectory();
+        final file = File('${dir.path}/tts_${DateTime.now().millisecondsSinceEpoch}.ogg');
+        await file.writeAsBytes(bytes);
+        filePath = file.path;
+      }
+    }
 
     final player = AudioPlayer();
-    await player.setFilePath(file.path);
+    await player.setFilePath(filePath);
 
     if (context.mounted) {
       ScaffoldMessenger.of(context).clearSnackBars();

--- a/lib/features/daily/journal/screens/entry_detail_screen.dart
+++ b/lib/features/daily/journal/screens/entry_detail_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:parachute/core/theme/design_tokens.dart';
 import 'package:parachute/core/widgets/note_links_section.dart';
+import 'package:parachute/core/widgets/read_aloud_button.dart';
 import 'package:parachute/core/widgets/tag_picker.dart';
 import 'package:parachute/core/widgets/wikilink_handler.dart';
 import 'package:parachute/core/widgets/wikilink_syntax.dart';
@@ -278,24 +279,28 @@ class _EntryDetailScreenState extends ConsumerState<EntryDetailScreen> {
               ),
             ),
           )
-        else if (widget.entry != null &&
-            widget.entry!.id != 'preamble' &&
-            !widget.entry!.id.startsWith('plain_'))
-          Padding(
-            padding: const EdgeInsets.only(right: 8),
-            child: TextButton.icon(
-              onPressed: _enterEditMode,
-              icon: Icon(Icons.edit, size: 18, color: BrandColors.forest),
-              label: Text(
-                'Edit',
-                style: TextStyle(
-                  color: BrandColors.forest,
-                  fontWeight: FontWeight.w600,
-                  fontSize: 16,
+        else ...[
+          if (widget.entry != null && widget.entry!.content.isNotEmpty)
+            ReadAloudButton(text: widget.entry!.content),
+          if (widget.entry != null &&
+              widget.entry!.id != 'preamble' &&
+              !widget.entry!.id.startsWith('plain_'))
+            Padding(
+              padding: const EdgeInsets.only(right: 8),
+              child: TextButton.icon(
+                onPressed: _enterEditMode,
+                icon: Icon(Icons.edit, size: 18, color: BrandColors.forest),
+                label: Text(
+                  'Edit',
+                  style: TextStyle(
+                    color: BrandColors.forest,
+                    fontWeight: FontWeight.w600,
+                    fontSize: 16,
+                  ),
                 ),
               ),
             ),
-          ),
+        ],
       ],
     );
   }

--- a/lib/features/daily/journal/screens/entry_detail_screen.dart
+++ b/lib/features/daily/journal/screens/entry_detail_screen.dart
@@ -281,7 +281,7 @@ class _EntryDetailScreenState extends ConsumerState<EntryDetailScreen> {
           )
         else ...[
           if (widget.entry != null && widget.entry!.content.isNotEmpty)
-            ReadAloudButton(text: widget.entry!.content),
+            ReadAloudButton(text: widget.entry!.content, noteId: widget.entry!.id),
           if (widget.entry != null &&
               widget.entry!.id != 'preamble' &&
               !widget.entry!.id.startsWith('plain_'))

--- a/lib/features/daily/journal/screens/journal_screen.dart
+++ b/lib/features/daily/journal/screens/journal_screen.dart
@@ -1246,7 +1246,7 @@ class _JournalScreenState extends ConsumerState<JournalScreen> with WidgetsBindi
                 title: const Text('Read aloud'),
                 onTap: () {
                   Navigator.pop(context);
-                  readAloudFromContext(context: this.context, ref: ref, text: entry.content);
+                  readAloudFromContext(context: this.context, ref: ref, text: entry.content, noteId: entry.id);
                 },
               ),
             ListTile(

--- a/lib/features/daily/journal/screens/journal_screen.dart
+++ b/lib/features/daily/journal/screens/journal_screen.dart
@@ -481,7 +481,11 @@ class _JournalScreenState extends ConsumerState<JournalScreen> with WidgetsBindi
     );
   }
 
-  /// Upload audio asset, create entry, enqueue on-device transcription.
+  /// Upload audio, transcribe via Scribe, create note with content + attachment.
+  ///
+  /// Transcription strategy: Scribe (server) first → on-device fallback → empty.
+  /// The note is created with whatever transcript is available so the vault
+  /// stores a fully-formed note. No vault trigger dependency.
   Future<void> _addVoiceEntryLocally(
     String transcript,
     String localAudioPath,
@@ -495,41 +499,80 @@ class _JournalScreenState extends ConsumerState<JournalScreen> with WidgetsBindi
     if (!mounted) return;
 
     if (serverPath != null) {
-      // Online: create entry with server audio path
+      // Online path: try Scribe transcription before creating the note.
+      String content = transcript; // on-device streaming transcript (may be empty)
+
+      final transcriptionService = ref.read(transcriptionApiServiceProvider);
+      if (transcriptionService != null) {
+        try {
+          debugPrint('[JournalScreen] Trying Scribe transcription...');
+          final scribeText = await transcriptionService.transcribe(localAudioPath);
+          if (scribeText.isNotEmpty) {
+            content = scribeText;
+            debugPrint('[JournalScreen] Scribe transcript: ${content.length} chars');
+          }
+        } catch (e) {
+          debugPrint('[JournalScreen] Scribe transcription failed: $e');
+          // Fall through to on-device fallback
+        }
+      }
+
+      // Create entry with transcript content
       final entry = await api.createEntry(
-        content: transcript,
+        content: content,
         createdAt: createdAt,
         metadata: {
           'type': 'voice',
           'audio_path': serverPath,
           'duration_seconds': duration,
-          if (transcript.isEmpty) 'transcription_status': 'processing',
+          'source': 'voice',
+          if (content.isEmpty) 'transcription_status': 'processing',
         },
       );
       if (!mounted) return;
 
       if (entry != null) {
+        // Attach audio to the note so vault has a proper attachment record
+        final ext = serverPath.split('.').last.toLowerCase();
+        final mime = switch (ext) {
+          'ogg' || 'opus' => 'audio/ogg',
+          'wav' => 'audio/wav',
+          'mp3' => 'audio/mpeg',
+          'm4a' || 'mp4' => 'audio/mp4',
+          _ => 'audio/ogg',
+        };
+        await api.addAttachment(entry.id, serverPath, mime);
+
         await _appendEntryToCache(
           entry,
-          content: transcript,
+          content: content,
           type: JournalEntryType.voice,
           audioPath: serverPath,
           durationSeconds: duration,
         );
 
-        // Enqueue on-device transcription — it owns the staged file lifecycle.
-        debugPrint('[JournalScreen] Enqueuing on-device transcription for ${entry.id}');
-        ref.read(postHocTranscriptionProvider.notifier).enqueue(
-          entryId: entry.id,
-          audioPath: localAudioPath,
-          durationSeconds: duration,
-        );
+        // If Scribe produced a transcript, we're done. Otherwise fall back
+        // to on-device post-hoc transcription.
+        if (content.isEmpty) {
+          debugPrint('[JournalScreen] No Scribe transcript — enqueuing on-device transcription for ${entry.id}');
+          ref.read(postHocTranscriptionProvider.notifier).enqueue(
+            entryId: entry.id,
+            audioPath: localAudioPath,
+            durationSeconds: duration,
+          );
+        } else {
+          // Transcript obtained — clean up local audio file
+          try {
+            await File(localAudioPath).delete();
+          } catch (e) {
+            debugPrint('[JournalScreen] Failed to delete staged audio: $e');
+          }
+        }
       } else {
-        // Upload succeeded but entry creation failed — queue with server path so audio
-        // is not re-uploaded, then clean up the local staged file.
+        // Upload succeeded but entry creation failed — queue with server path
         await _appendEntryToCache(
           null,
-          content: transcript,
+          content: content,
           type: JournalEntryType.voice,
           audioPath: serverPath,
           durationSeconds: duration,

--- a/lib/features/daily/journal/screens/journal_screen.dart
+++ b/lib/features/daily/journal/screens/journal_screen.dart
@@ -8,7 +8,8 @@ import 'package:path_provider/path_provider.dart';
 import 'package:parachute/core/config/app_config.dart';
 import 'package:parachute/core/theme/design_tokens.dart';
 import 'package:parachute/core/providers/backend_health_provider.dart'
-    show transcriptionApiServiceProvider, transcriptionServiceReachableProvider;
+    show transcriptionApiServiceProvider, transcriptionServiceReachableProvider, ttsApiServiceProvider;
+import 'package:parachute/core/widgets/read_aloud_button.dart' show readAloudFromContext;
 import 'package:parachute/core/providers/app_state_provider.dart' show apiKeyProvider;
 import 'package:parachute/core/providers/feature_flags_provider.dart' show aiServerUrlProvider;
 import 'package:parachute/core/providers/connectivity_provider.dart' show isServerAvailableProvider;
@@ -1237,6 +1238,15 @@ class _JournalScreenState extends ConsumerState<JournalScreen> with WidgetsBindi
                 onTap: () {
                   Navigator.pop(context);
                   _copyEntryContent(entry);
+                },
+              ),
+            if (entry.content.isNotEmpty && ref.read(ttsApiServiceProvider) != null)
+              ListTile(
+                leading: Icon(Icons.volume_up_outlined, color: BrandColors.turquoise),
+                title: const Text('Read aloud'),
+                onTap: () {
+                  Navigator.pop(context);
+                  readAloudFromContext(context: this.context, ref: ref, text: entry.content);
                 },
               ),
             ListTile(

--- a/lib/features/daily/journal/services/daily_api_service.dart
+++ b/lib/features/daily/journal/services/daily_api_service.dart
@@ -245,9 +245,14 @@ class DailyApiService {
   }
 
   /// Upload audio and create a voice note with attachment.
+  ///
+  /// [content] is the transcript text (from Scribe or on-device). The note
+  /// is created with this content so the vault stores a fully-formed note
+  /// rather than relying on triggers for transcription.
   Future<Note?> uploadVoiceNote({
     required File audioFile,
     required int durationSeconds,
+    String content = '',
     String? date,
     String? replaceNoteId,
   }) async {
@@ -260,16 +265,13 @@ class DailyApiService {
       await deleteNote(replaceNoteId);
     }
 
-    // Create a note tagged daily + voice
+    // Create note with transcript content
     final note = await createNote(
-      content: '',
+      content: content,
       tags: ['captured'],
     );
 
-    // Attach the audio file to the note. Infer mime from the uploaded
-    // file extension so we don't hardcode audio/wav after the Opus
-    // migration — voice memos are .ogg now, older callers may pass
-    // other formats, and the server's storage layer already normalizes.
+    // Attach the audio file to the note
     if (note != null && audioPath.isNotEmpty) {
       final ext = audioPath.split('.').last.toLowerCase();
       final mime = switch (ext) {

--- a/lib/features/daily/journal/widgets/journal_entry_card.dart
+++ b/lib/features/daily/journal/widgets/journal_entry_card.dart
@@ -23,6 +23,7 @@ class JournalEntryCard extends ConsumerWidget {
   final VoidCallback? onDelete;
   final VoidCallback? onTranscribe;
   final VoidCallback? onEnhance;
+  final VoidCallback? onReadAloud;
 
   const JournalEntryCard({
     super.key,
@@ -33,6 +34,7 @@ class JournalEntryCard extends ConsumerWidget {
     this.onDelete,
     this.onTranscribe,
     this.onEnhance,
+    this.onReadAloud,
   });
 
   /// Check if this is imported markdown content (no para:ID)
@@ -379,6 +381,9 @@ class JournalEntryCard extends ConsumerWidget {
           case 'edit':
             onEdit?.call();
             break;
+          case 'read_aloud':
+            onReadAloud?.call();
+            break;
           case 'delete':
             onDelete?.call();
             break;
@@ -395,6 +400,17 @@ class JournalEntryCard extends ConsumerWidget {
             ],
           ),
         ),
+        if (onReadAloud != null && entry.content.isNotEmpty)
+          const PopupMenuItem(
+            value: 'read_aloud',
+            child: Row(
+              children: [
+                Icon(Icons.volume_up_outlined, size: 18),
+                SizedBox(width: 8),
+                Text('Read aloud'),
+              ],
+            ),
+          ),
         PopupMenuItem(
           value: 'delete',
           child: Row(

--- a/lib/features/daily/recorder/providers/service_providers.dart
+++ b/lib/features/daily/recorder/providers/service_providers.dart
@@ -13,6 +13,8 @@ const String _autoEnhanceKey = 'auto_enhance';
 const String _transcriptionModeKey = 'transcription_mode';
 const String _transcriptionServiceUrlKey = 'transcription_service_url';
 const String _transcriptionServiceApiKeyKey = 'transcription_service_api_key';
+const String _ttsServiceUrlKey = 'tts_service_url';
+const String _ttsServiceApiKeyKey = 'tts_service_api_key';
 
 /// Transcription mode: where voice entries get transcribed.
 ///
@@ -119,6 +121,65 @@ final isTranscriptionServiceConfiguredProvider = Provider<bool>((ref) {
   final urlAsync = ref.watch(transcriptionServiceUrlProvider);
   final url = urlAsync.valueOrNull;
   return url != null && url.isNotEmpty;
+});
+
+// ===========================================================================
+// TTS (Narrate) Service
+// ===========================================================================
+
+/// Provider for TTS service URL (Narrate endpoint)
+final ttsServiceUrlProvider = FutureProvider<String?>((ref) async {
+  final prefs = await SharedPreferences.getInstance();
+  return prefs.getString(_ttsServiceUrlKey);
+});
+
+/// Set TTS service URL
+Future<void> setTtsServiceUrl(String? url) async {
+  final prefs = await SharedPreferences.getInstance();
+  if (url != null && url.isNotEmpty) {
+    await prefs.setString(_ttsServiceUrlKey, url);
+  } else {
+    await prefs.remove(_ttsServiceUrlKey);
+  }
+}
+
+/// Notifier for TTS service API key with secure storage.
+class TtsApiKeyNotifier extends AsyncNotifier<String?> {
+  static const _secureStorage = FlutterSecureStorage();
+
+  @override
+  Future<String?> build() async {
+    final secureKey = await _secureStorage.read(key: _ttsServiceApiKeyKey);
+    if (secureKey != null) return secureKey;
+
+    // Migrate from SharedPreferences if present
+    final prefs = await SharedPreferences.getInstance();
+    final legacyKey = prefs.getString(_ttsServiceApiKeyKey);
+    if (legacyKey != null) {
+      await _secureStorage.write(key: _ttsServiceApiKeyKey, value: legacyKey);
+      await prefs.remove(_ttsServiceApiKeyKey);
+      debugPrint('[TtsApiKey] Migrated from SharedPreferences to secure storage');
+      return legacyKey;
+    }
+
+    return null;
+  }
+
+  Future<void> setApiKey(String? key) async {
+    if (key != null && key.isNotEmpty) {
+      await _secureStorage.write(key: _ttsServiceApiKeyKey, value: key);
+      state = AsyncData(key);
+    } else {
+      await _secureStorage.delete(key: _ttsServiceApiKeyKey);
+      state = const AsyncData(null);
+    }
+  }
+}
+
+/// Provider for TTS service API key (secure storage)
+final ttsServiceApiKeyProvider =
+    AsyncNotifierProvider<TtsApiKeyNotifier, String?>(() {
+  return TtsApiKeyNotifier();
 });
 
 /// Provider for AudioService

--- a/lib/features/digest/screens/digest_screen.dart
+++ b/lib/features/digest/screens/digest_screen.dart
@@ -1,8 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:parachute/core/models/thing.dart';
+import 'package:parachute/core/providers/backend_health_provider.dart'
+    show ttsApiServiceProvider;
 import 'package:parachute/core/screens/note_detail_screen.dart';
 import 'package:parachute/core/theme/design_tokens.dart';
+import 'package:parachute/core/widgets/read_aloud_button.dart'
+    show readAloudFromContext;
 import 'package:parachute/features/daily/journal/providers/journal_providers.dart';
 import 'package:parachute/features/vault/providers/vault_providers.dart';
 import '../providers/digest_providers.dart';
@@ -418,9 +422,30 @@ class _DigestCard extends ConsumerWidget {
               await _togglePin(context, ref);
             case 'archive':
               await _toggleArchive(context, ref);
+            case 'read_aloud':
+              if (context.mounted) {
+                readAloudFromContext(
+                  context: context,
+                  ref: ref,
+                  text: note.content,
+                  noteId: note.id,
+                );
+              }
           }
         },
         itemBuilder: (context) => [
+          if (note.content.isNotEmpty &&
+              ref.read(ttsApiServiceProvider) != null)
+            PopupMenuItem(
+              value: 'read_aloud',
+              child: Row(
+                children: [
+                  Icon(Icons.volume_up_outlined, size: 18, color: BrandColors.turquoise),
+                  const SizedBox(width: 12),
+                  const Text('Read aloud'),
+                ],
+              ),
+            ),
           PopupMenuItem(
             value: 'pin',
             child: Row(

--- a/lib/features/settings/screens/settings_screen.dart
+++ b/lib/features/settings/screens/settings_screen.dart
@@ -7,6 +7,7 @@ import '../widgets/server_settings_section.dart';
 import '../widgets/transcription_settings_section.dart';
 import '../widgets/about_section.dart';
 import '../widgets/settings_card.dart';
+import '../widgets/tts_service_section.dart';
 
 /// Settings screen for Parachute Daily v2
 ///
@@ -49,6 +50,13 @@ class SettingsScreen extends ConsumerWidget {
           SettingsCard(
             isDark: isDark,
             child: const TranscriptionSettingsSection(),
+          ),
+
+          // TTS (Read Aloud / Narrate)
+          SizedBox(height: Spacing.xl),
+          SettingsCard(
+            isDark: isDark,
+            child: const TtsServiceSection(),
           ),
 
           // Omi Device (iOS/Android only)

--- a/lib/features/settings/screens/settings_screen.dart
+++ b/lib/features/settings/screens/settings_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:parachute/core/theme/design_tokens.dart';
 import '../widgets/omi_device_section.dart';
 import '../widgets/server_settings_section.dart';
+import '../widgets/transcription_service_section.dart';
 import '../widgets/transcription_settings_section.dart';
 import '../widgets/about_section.dart';
 import '../widgets/settings_card.dart';
@@ -12,8 +13,10 @@ import '../widgets/tts_service_section.dart';
 /// Settings screen for Parachute Daily v2
 ///
 /// Sections:
-/// - Server URL
-/// - Transcription
+/// - Vault Server (URL + API key)
+/// - Transcription Mode (auto / server / local)
+/// - Transcription Service / Scribe (URL + optional API key)
+/// - TTS / Narrate (URL + optional API key)
 /// - Omi Device (mobile only)
 /// - About
 class SettingsScreen extends ConsumerWidget {
@@ -52,7 +55,14 @@ class SettingsScreen extends ConsumerWidget {
             child: const TranscriptionSettingsSection(),
           ),
 
-          // TTS (Read Aloud / Narrate)
+          // Transcription Service / Scribe
+          SizedBox(height: Spacing.xl),
+          SettingsCard(
+            isDark: isDark,
+            child: const TranscriptionServiceSection(),
+          ),
+
+          // TTS / Narrate (Read Aloud)
           SizedBox(height: Spacing.xl),
           SettingsCard(
             isDark: isDark,

--- a/lib/features/settings/widgets/server_settings_section.dart
+++ b/lib/features/settings/widgets/server_settings_section.dart
@@ -7,10 +7,8 @@ import 'package:parachute/core/providers/app_state_provider.dart'
 import 'package:parachute/core/providers/feature_flags_provider.dart';
 import 'package:parachute/core/services/backend_health_service.dart';
 import 'package:parachute/core/services/graph_api_service.dart';
-import 'package:parachute/core/services/transcription_api_service.dart';
-import 'package:parachute/features/daily/recorder/providers/service_providers.dart';
 
-/// Server connection settings section with vault picker and transcription config.
+/// Server connection settings section — vault URL, API key, vault picker.
 class ServerSettingsSection extends ConsumerStatefulWidget {
   const ServerSettingsSection({super.key});
 
@@ -21,13 +19,10 @@ class ServerSettingsSection extends ConsumerStatefulWidget {
 class _ServerSettingsSectionState extends ConsumerState<ServerSettingsSection> {
   final _serverUrlController = TextEditingController();
   final _apiKeyController = TextEditingController();
-  final _transcriptionUrlController = TextEditingController();
-  final _transcriptionApiKeyController = TextEditingController();
 
   List<String>? _availableVaults;
   String? _selectedVault;
   bool _loadingVaults = false;
-  bool _useCustomTranscription = false;
 
   @override
   void initState() {
@@ -39,8 +34,6 @@ class _ServerSettingsSectionState extends ConsumerState<ServerSettingsSection> {
   void dispose() {
     _serverUrlController.dispose();
     _apiKeyController.dispose();
-    _transcriptionUrlController.dispose();
-    _transcriptionApiKeyController.dispose();
     super.dispose();
   }
 
@@ -49,24 +42,12 @@ class _ServerSettingsSectionState extends ConsumerState<ServerSettingsSection> {
     final serverUrl = await featureFlags.getAiServerUrl();
     final apiKey = ref.read(apiKeyProvider).valueOrNull;
     final vaultName = ref.read(vaultNameProvider).valueOrNull;
-    final transcriptionUrl =
-        await ref.read(transcriptionServiceUrlProvider.future);
-    final transcriptionApiKey =
-        await ref.read(transcriptionServiceApiKeyProvider.future);
 
     if (mounted) {
       setState(() {
         _serverUrlController.text = serverUrl;
         if (apiKey != null) _apiKeyController.text = apiKey;
         _selectedVault = vaultName;
-        _useCustomTranscription =
-            transcriptionUrl != null && transcriptionUrl.isNotEmpty;
-        if (transcriptionUrl != null) {
-          _transcriptionUrlController.text = transcriptionUrl;
-        }
-        if (transcriptionApiKey != null) {
-          _transcriptionApiKeyController.text = transcriptionApiKey;
-        }
       });
 
       // Fetch vaults if we have a URL
@@ -157,30 +138,9 @@ class _ServerSettingsSectionState extends ConsumerState<ServerSettingsSection> {
         .setVaultName(name == null || name.isEmpty ? null : name);
   }
 
-  Future<void> _saveTranscriptionUrl() async {
-    final url = _transcriptionUrlController.text.trim();
-    await setTranscriptionServiceUrl(url.isEmpty ? null : url);
-    ref.invalidate(transcriptionServiceUrlProvider);
-  }
-
-  Future<void> _saveTranscriptionApiKey() async {
-    final key = _transcriptionApiKeyController.text.trim();
-    await ref
-        .read(transcriptionServiceApiKeyProvider.notifier)
-        .setApiKey(key.isEmpty ? null : key);
-  }
-
   Future<void> _saveAll() async {
     await _saveServerUrl();
     await _saveApiKey(showSnackbar: false);
-    if (_useCustomTranscription) {
-      await _saveTranscriptionUrl();
-      await _saveTranscriptionApiKey();
-    } else {
-      // Clear custom transcription when using vault
-      await setTranscriptionServiceUrl(null);
-      ref.invalidate(transcriptionServiceUrlProvider);
-    }
   }
 
   Future<void> _testServerConnection() async {
@@ -220,33 +180,14 @@ class _ServerSettingsSectionState extends ConsumerState<ServerSettingsSection> {
     try {
       final status = await healthService.checkHealth();
 
-      // Also test transcription endpoint
-      final transcriptionUrl = _useCustomTranscription
-          ? _transcriptionUrlController.text.trim()
-          : url;
-      final transcriptionKey = _useCustomTranscription
-          ? _transcriptionApiKeyController.text.trim()
-          : _apiKeyController.text.trim();
-      final transcriptionService = TranscriptionApiService(
-        baseUrl: transcriptionUrl,
-        apiKey: transcriptionKey.isEmpty ? null : transcriptionKey,
-      );
-      final transcriptionResult = await transcriptionService.checkConnection();
-      transcriptionService.dispose();
-
       if (mounted) {
         ScaffoldMessenger.of(context).clearSnackBars();
         if (status.isHealthy) {
-          final transcriptionMsg = transcriptionResult.authOk
-              ? ' · Transcription ready'
-              : transcriptionResult.reachable
-                  ? ' · Transcription auth failed'
-                  : '';
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(
               content: Text(status.serverVersion != null
-                  ? 'Connected to Parachute Computer v${status.serverVersion}$transcriptionMsg'
-                  : 'Connected to Parachute Computer$transcriptionMsg'),
+                  ? 'Connected to Parachute Computer v${status.serverVersion}'
+                  : 'Connected to Parachute Computer'),
               backgroundColor: BrandColors.success,
             ),
           );
@@ -301,7 +242,7 @@ class _ServerSettingsSectionState extends ConsumerState<ServerSettingsSection> {
         ),
         SizedBox(height: Spacing.sm),
         Text(
-          'Connect to a Parachute Vault for sync, search, and transcription. '
+          'Connect to a Parachute Vault for sync and search. '
           'Leave empty for offline mode.',
           style: TextStyle(
             fontSize: TypographyTokens.bodySmall,
@@ -356,16 +297,6 @@ class _ServerSettingsSectionState extends ConsumerState<ServerSettingsSection> {
 
         // Vault picker
         _buildVaultPicker(isDark),
-        SizedBox(height: Spacing.lg),
-
-        // Transcription toggle
-        _buildTranscriptionToggle(isDark),
-
-        // Custom transcription fields (collapsed by default)
-        if (_useCustomTranscription) ...[
-          SizedBox(height: Spacing.md),
-          _buildCustomTranscriptionFields(),
-        ],
         SizedBox(height: Spacing.lg),
 
         // Action buttons
@@ -423,7 +354,7 @@ class _ServerSettingsSectionState extends ConsumerState<ServerSettingsSection> {
     }
 
     return DropdownButtonFormField<String>(
-      value: _selectedVault,
+      initialValue: _selectedVault,
       decoration: const InputDecoration(
         labelText: 'Vault',
         border: OutlineInputBorder(),
@@ -440,93 +371,6 @@ class _ServerSettingsSectionState extends ConsumerState<ServerSettingsSection> {
             )),
       ],
       onChanged: (name) => _saveVaultName(name),
-    );
-  }
-
-  Widget _buildTranscriptionToggle(bool isDark) {
-    return Row(
-      children: [
-        Icon(
-          Icons.record_voice_over,
-          size: 18,
-          color: isDark ? BrandColors.nightTextSecondary : BrandColors.driftwood,
-        ),
-        SizedBox(width: Spacing.sm),
-        Expanded(
-          child: Text(
-            _useCustomTranscription
-                ? 'Using custom transcription endpoint'
-                : 'Transcription via this server',
-            style: TextStyle(
-              fontSize: TypographyTokens.bodySmall,
-              color:
-                  isDark ? BrandColors.nightText : BrandColors.charcoal,
-            ),
-          ),
-        ),
-        TextButton(
-          onPressed: () {
-            setState(() {
-              _useCustomTranscription = !_useCustomTranscription;
-            });
-            if (!_useCustomTranscription) {
-              // Clear custom URL when switching back to vault
-              _transcriptionUrlController.clear();
-              _transcriptionApiKeyController.clear();
-              _saveTranscriptionUrl();
-              _saveTranscriptionApiKey();
-            }
-          },
-          child: Text(
-            _useCustomTranscription ? 'Use server' : 'Custom endpoint',
-            style: const TextStyle(fontSize: 12),
-          ),
-        ),
-      ],
-    );
-  }
-
-  Widget _buildCustomTranscriptionFields() {
-    return Column(
-      children: [
-        TextField(
-          controller: _transcriptionUrlController,
-          decoration: InputDecoration(
-            labelText: 'Transcription URL',
-            hintText: 'https://api.groq.com/openai',
-            border: const OutlineInputBorder(),
-            prefixIcon: const Icon(Icons.link),
-            suffixIcon: IconButton(
-              icon: const Icon(Icons.clear),
-              onPressed: () {
-                _transcriptionUrlController.clear();
-                _saveTranscriptionUrl();
-              },
-            ),
-          ),
-          keyboardType: TextInputType.url,
-          onSubmitted: (_) => _saveTranscriptionUrl(),
-        ),
-        SizedBox(height: Spacing.md),
-        TextField(
-          controller: _transcriptionApiKeyController,
-          decoration: InputDecoration(
-            labelText: 'Transcription API Key',
-            hintText: 'sk-...',
-            border: const OutlineInputBorder(),
-            prefixIcon: const Icon(Icons.key),
-            suffixIcon: IconButton(
-              icon: const Icon(Icons.clear),
-              onPressed: () {
-                _transcriptionApiKeyController.clear();
-                _saveTranscriptionApiKey();
-              },
-            ),
-          ),
-          obscureText: true,
-          onSubmitted: (_) => _saveTranscriptionApiKey(),
-        ),
-      ],
     );
   }
 }

--- a/lib/features/settings/widgets/server_settings_section.dart
+++ b/lib/features/settings/widgets/server_settings_section.dart
@@ -176,7 +176,11 @@ class _ServerSettingsSectionState extends ConsumerState<ServerSettingsSection> {
       ),
     );
 
-    final healthService = BackendHealthService(baseUrl: url);
+    final apiKey = _apiKeyController.text.trim();
+    final healthService = BackendHealthService(
+      baseUrl: url,
+      apiKey: apiKey.isEmpty ? null : apiKey,
+    );
     try {
       final status = await healthService.checkHealth();
 

--- a/lib/features/settings/widgets/transcription_service_section.dart
+++ b/lib/features/settings/widgets/transcription_service_section.dart
@@ -199,7 +199,7 @@ class _TranscriptionServiceSectionState
         TextField(
           controller: _apiKeyController,
           decoration: InputDecoration(
-            labelText: 'API Key',
+            labelText: 'API Key (optional)',
             hintText: 'sk-...',
             border: const OutlineInputBorder(),
             prefixIcon: const Icon(Icons.key),

--- a/lib/features/settings/widgets/tts_service_section.dart
+++ b/lib/features/settings/widgets/tts_service_section.dart
@@ -1,0 +1,240 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:parachute/core/theme/design_tokens.dart';
+import 'package:parachute/core/services/tts_api_service.dart';
+import 'package:parachute/features/daily/recorder/providers/service_providers.dart';
+
+/// Settings section for configuring a TTS service (Narrate / OpenAI TTS-compatible).
+class TtsServiceSection extends ConsumerStatefulWidget {
+  const TtsServiceSection({super.key});
+
+  @override
+  ConsumerState<TtsServiceSection> createState() => _TtsServiceSectionState();
+}
+
+class _TtsServiceSectionState extends ConsumerState<TtsServiceSection> {
+  final _urlController = TextEditingController();
+  final _apiKeyController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _loadSettings();
+  }
+
+  @override
+  void dispose() {
+    _urlController.dispose();
+    _apiKeyController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _loadSettings() async {
+    final url = await ref.read(ttsServiceUrlProvider.future);
+    final apiKey = await ref.read(ttsServiceApiKeyProvider.future);
+    if (mounted) {
+      if (url != null) _urlController.text = url;
+      if (apiKey != null) _apiKeyController.text = apiKey;
+    }
+  }
+
+  Future<void> _saveUrl() async {
+    final url = _urlController.text.trim();
+    await setTtsServiceUrl(url.isEmpty ? null : url);
+    ref.invalidate(ttsServiceUrlProvider);
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(url.isEmpty
+              ? 'TTS service URL cleared'
+              : 'TTS service URL saved'),
+          backgroundColor: BrandColors.success,
+        ),
+      );
+    }
+  }
+
+  Future<void> _saveApiKey({bool showSnackbar = true}) async {
+    final key = _apiKeyController.text.trim();
+    await ref.read(ttsServiceApiKeyProvider.notifier).setApiKey(
+      key.isEmpty ? null : key,
+    );
+    if (showSnackbar && mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(key.isEmpty ? 'API key cleared' : 'API key saved'),
+          backgroundColor: BrandColors.success,
+        ),
+      );
+    }
+  }
+
+  Future<void> _testConnection() async {
+    final url = _urlController.text.trim();
+    if (url.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: const Text('Enter a TTS service URL first'),
+          backgroundColor: BrandColors.warning,
+        ),
+      );
+      return;
+    }
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Row(
+          children: [
+            SizedBox(
+              width: 16,
+              height: 16,
+              child: CircularProgressIndicator(
+                strokeWidth: 2,
+                valueColor:
+                    AlwaysStoppedAnimation<Color>(BrandColors.softWhite),
+              ),
+            ),
+            SizedBox(width: Spacing.md),
+            const Text('Testing connection...'),
+          ],
+        ),
+        duration: const Duration(seconds: 10),
+      ),
+    );
+
+    final apiKey = _apiKeyController.text.trim();
+    final service = TtsApiService(
+      baseUrl: url,
+      apiKey: apiKey.isEmpty ? null : apiKey,
+    );
+
+    try {
+      final ok = await service.checkConnection();
+      if (mounted) {
+        ScaffoldMessenger.of(context).clearSnackBars();
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(ok ? 'Connected to TTS service' : 'TTS service not reachable'),
+            backgroundColor: ok ? BrandColors.success : BrandColors.error,
+          ),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).clearSnackBars();
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Connection failed: $e'),
+            backgroundColor: BrandColors.error,
+          ),
+        );
+      }
+    } finally {
+      service.dispose();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Icon(
+              Icons.volume_up,
+              color: isDark ? BrandColors.nightTurquoise : BrandColors.turquoise,
+            ),
+            SizedBox(width: Spacing.sm),
+            Text(
+              'Read Aloud (Narrate)',
+              style: TextStyle(
+                fontWeight: FontWeight.bold,
+                fontSize: TypographyTokens.bodyLarge,
+                color: isDark ? BrandColors.nightText : BrandColors.charcoal,
+              ),
+            ),
+          ],
+        ),
+        SizedBox(height: Spacing.sm),
+        Text(
+          'Connect to an OpenAI TTS-compatible endpoint '
+          '(Narrate, OpenAI, etc.) to read notes aloud.',
+          style: TextStyle(
+            fontSize: TypographyTokens.bodySmall,
+            color: isDark ? BrandColors.nightTextSecondary : BrandColors.driftwood,
+          ),
+        ),
+        SizedBox(height: Spacing.lg),
+
+        TextField(
+          controller: _urlController,
+          decoration: InputDecoration(
+            labelText: 'Service URL',
+            hintText: 'http://192.168.1.100:5912',
+            border: const OutlineInputBorder(),
+            prefixIcon: const Icon(Icons.link),
+            suffixIcon: IconButton(
+              icon: const Icon(Icons.clear),
+              onPressed: () {
+                _urlController.clear();
+                _saveUrl();
+              },
+            ),
+          ),
+          keyboardType: TextInputType.url,
+          onSubmitted: (_) => _saveUrl(),
+        ),
+        SizedBox(height: Spacing.md),
+
+        TextField(
+          controller: _apiKeyController,
+          decoration: InputDecoration(
+            labelText: 'API Key (optional)',
+            hintText: 'sk-...',
+            border: const OutlineInputBorder(),
+            prefixIcon: const Icon(Icons.key),
+            suffixIcon: IconButton(
+              icon: const Icon(Icons.clear),
+              onPressed: () {
+                _apiKeyController.clear();
+                _saveApiKey();
+              },
+            ),
+          ),
+          obscureText: true,
+          onSubmitted: (_) => _saveApiKey(),
+        ),
+        SizedBox(height: Spacing.lg),
+
+        Row(
+          children: [
+            Expanded(
+              child: OutlinedButton.icon(
+                onPressed: _testConnection,
+                icon: const Icon(Icons.wifi_tethering, size: 18),
+                label: const Text('Test Connection'),
+              ),
+            ),
+            SizedBox(width: Spacing.sm),
+            Expanded(
+              child: FilledButton.icon(
+                onPressed: () async {
+                  await _saveUrl();
+                  await _saveApiKey(showSnackbar: false);
+                },
+                icon: const Icon(Icons.save, size: 18),
+                label: const Text('Save'),
+                style: FilledButton.styleFrom(
+                  backgroundColor: BrandColors.turquoise,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -250,7 +250,7 @@ packages:
     source: hosted
     version: "0.3.5+1"
   crypto:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: crypto
       sha256: c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
 
   # Utilities
   collection: ^1.18.0
+  crypto: ^3.0.0
   http: ^1.2.0
   archive: ^3.6.1
 


### PR DESCRIPTION
## Summary

- Daily now transcribes voice memos via Scribe (server-side Whisper) before creating the vault note. The note is created with transcript content + proper audio attachment. No vault trigger dependency.
- Fallback chain: **Scribe** (server, higher quality) → **on-device post-hoc** (Parakeet, local) → **empty content** (audio still saved).
- Supersedes #100 (race condition fix). The race condition is moot because Daily owns the transcription pipeline end-to-end.

## Changes

### `journal_screen.dart` — `_addVoiceEntryLocally`
- After uploading audio to vault storage, tries Scribe transcription via `TranscriptionApiService` (already configured from settings)
- If Scribe succeeds: creates note with transcript content, no post-hoc needed
- If Scribe fails: creates note with empty content, enqueues on-device post-hoc transcription (existing pipeline)
- Adds audio as a proper vault attachment (`addAttachment`) — previously only stored in metadata

### `daily_api_service.dart` — `uploadVoiceNote`
- Added optional `content` parameter (defaults to `''`) so callers can provide a transcript

## How the fallback works

```
Recording stops
  ↓
Upload audio to vault storage
  ↓
Try Scribe transcription (TranscriptionApiService)
  ├─ Success → content = Scribe transcript
  │            → Create note with content + attachment
  │            → Clean up local audio file → Done
  │
  └─ Failure → content = '' (empty)
               → Create note with empty content + attachment
               → Enqueue on-device post-hoc transcription
               → Post-hoc updates note content when ready
```

If offline: note is saved to local cache with staged audio path, flushed on reconnect.

## Test plan

- [ ] Record a voice memo with Scribe running → verify note has transcript immediately
- [ ] Stop Scribe, record a voice memo → verify on-device transcription kicks in
- [ ] Verify audio attachment appears on the vault note (not just metadata)
- [ ] Test offline recording → reconnect → verify flush creates note correctly
- [ ] Retranscribe existing entry via long-press menu still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)