### PR TITLE
feat(oauth): add 'Connect to Vault' OAuth 2.1 + PKCE flow

### DIFF
--- a/lib/features/settings/services/oauth_service.dart
+++ b/lib/features/settings/services/oauth_service.dart
@@ -1,0 +1,323 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:math';
+
+import 'package:app_links/app_links.dart';
+import 'package:crypto/crypto.dart';
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+import 'package:url_launcher/url_launcher.dart';
+
+/// Result of a successful OAuth flow.
+class OAuthResult {
+  final String token;
+  final String? scope;
+  final String? vaultName;
+
+  const OAuthResult({required this.token, this.scope, this.vaultName});
+}
+
+/// Raised when the user cancels the flow, the server rejects auth,
+/// or discovery/registration/token exchange fails.
+class OAuthException implements Exception {
+  final String message;
+  final String? code;
+  OAuthException(this.message, {this.code});
+
+  @override
+  String toString() => code == null ? 'OAuthException: $message' : 'OAuthException($code): $message';
+}
+
+/// OAuth 2.1 + PKCE client for Parachute Vault.
+///
+/// Implements just enough of OAuth for the connect-to-vault flow:
+///   1. Discover endpoints via `/.well-known/oauth-authorization-server`
+///   2. Dynamic client registration (RFC 7591)
+///   3. Launch the browser to the authorization endpoint
+///   4. Receive the redirect via the app's `parachute://oauth/callback` deep link
+///   5. Exchange the code for a token at the token endpoint
+///
+/// The returned token is a standard `pvt_` vault token — identical to manually
+/// created API keys, and stored the same way.
+class OAuthService {
+  static const String redirectUri = 'parachute://oauth/callback';
+  static const String clientName = 'Parachute Daily';
+
+  final http.Client _http;
+  final AppLinks _appLinks;
+
+  OAuthService({http.Client? httpClient, AppLinks? appLinks})
+      : _http = httpClient ?? http.Client(),
+        _appLinks = appLinks ?? AppLinks();
+
+  /// Run the full OAuth flow. Returns the resulting token on success.
+  /// Throws [OAuthException] if cancelled, timed out, or rejected.
+  ///
+  /// [serverUrl] is the vault base URL (e.g. `https://parachute.example.ts.net`).
+  /// [timeout] applies to the whole browser + redirect window.
+  Future<OAuthResult> connect({
+    required String serverUrl,
+    Duration timeout = const Duration(minutes: 5),
+  }) async {
+    final normalizedUrl = _normalizeServerUrl(serverUrl);
+
+    // 1. Discovery
+    final discovery = await _discover(normalizedUrl);
+
+    // 2. Dynamic client registration
+    final clientId = await _register(discovery.registrationEndpoint);
+
+    // 3. PKCE
+    final verifier = _generateCodeVerifier();
+    final challenge = _codeChallenge(verifier);
+    final state = _randomString(32);
+
+    // 4. Start listening for the redirect BEFORE launching the browser,
+    //    so we don't miss a fast callback.
+    final callbackFuture = _waitForCallback(state: state, timeout: timeout);
+
+    // 5. Launch browser
+    final authUri = Uri.parse(discovery.authorizationEndpoint).replace(
+      queryParameters: {
+        'response_type': 'code',
+        'client_id': clientId,
+        'redirect_uri': redirectUri,
+        'code_challenge': challenge,
+        'code_challenge_method': 'S256',
+        'state': state,
+      },
+    );
+    final launched = await launchUrl(authUri, mode: LaunchMode.externalApplication);
+    if (!launched) {
+      throw OAuthException('Could not open browser for authorization', code: 'launch_failed');
+    }
+
+    // 6. Await the redirect
+    final callback = await callbackFuture;
+
+    if (callback.error != null) {
+      throw OAuthException(
+        callback.errorDescription ?? callback.error!,
+        code: callback.error,
+      );
+    }
+    final code = callback.code;
+    if (code == null) {
+      throw OAuthException('Authorization callback missing code', code: 'invalid_response');
+    }
+
+    // 7. Exchange code for token
+    return await _exchange(
+      tokenEndpoint: discovery.tokenEndpoint,
+      code: code,
+      verifier: verifier,
+      clientId: clientId,
+    );
+  }
+
+  Future<_Discovery> _discover(String serverUrl) async {
+    // Try RFC 8414 authorization-server metadata first.
+    final authServerUrl = Uri.parse('$serverUrl/.well-known/oauth-authorization-server');
+    try {
+      final resp = await _http.get(authServerUrl).timeout(const Duration(seconds: 10));
+      if (resp.statusCode == 200) {
+        final data = json.decode(resp.body) as Map<String, dynamic>;
+        final auth = data['authorization_endpoint'] as String?;
+        final token = data['token_endpoint'] as String?;
+        final reg = data['registration_endpoint'] as String?;
+        if (auth != null && token != null && reg != null) {
+          return _Discovery(
+            authorizationEndpoint: auth,
+            tokenEndpoint: token,
+            registrationEndpoint: reg,
+          );
+        }
+      }
+    } catch (e) {
+      debugPrint('[OAuth] authorization-server discovery failed: $e');
+    }
+
+    // Fallback: protected-resource discovery points at an authorization server.
+    final prUrl = Uri.parse('$serverUrl/.well-known/oauth-protected-resource');
+    try {
+      final resp = await _http.get(prUrl).timeout(const Duration(seconds: 10));
+      if (resp.statusCode == 200) {
+        final data = json.decode(resp.body) as Map<String, dynamic>;
+        final authServers = (data['authorization_servers'] as List?)?.cast<String>();
+        if (authServers != null && authServers.isNotEmpty) {
+          // Recurse once using the first advertised AS.
+          return await _discover(authServers.first.replaceAll(RegExp(r'/$'), ''));
+        }
+      }
+    } catch (e) {
+      debugPrint('[OAuth] protected-resource discovery failed: $e');
+    }
+
+    throw OAuthException(
+      'Server does not advertise OAuth metadata. Is this a Parachute Vault?',
+      code: 'discovery_failed',
+    );
+  }
+
+  Future<String> _register(String registrationEndpoint) async {
+    final resp = await _http.post(
+      Uri.parse(registrationEndpoint),
+      headers: {'Content-Type': 'application/json'},
+      body: json.encode({
+        'client_name': clientName,
+        'redirect_uris': [redirectUri],
+        'token_endpoint_auth_method': 'none',
+        'grant_types': ['authorization_code'],
+        'response_types': ['code'],
+      }),
+    ).timeout(const Duration(seconds: 10));
+
+    if (resp.statusCode != 200 && resp.statusCode != 201) {
+      throw OAuthException(
+        'Client registration failed (${resp.statusCode}): ${resp.body}',
+        code: 'registration_failed',
+      );
+    }
+    final data = json.decode(resp.body) as Map<String, dynamic>;
+    final clientId = data['client_id'] as String?;
+    if (clientId == null) {
+      throw OAuthException('Registration response missing client_id', code: 'registration_failed');
+    }
+    return clientId;
+  }
+
+  Future<OAuthResult> _exchange({
+    required String tokenEndpoint,
+    required String code,
+    required String verifier,
+    required String clientId,
+  }) async {
+    final resp = await _http.post(
+      Uri.parse(tokenEndpoint),
+      headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+      body: {
+        'grant_type': 'authorization_code',
+        'code': code,
+        'redirect_uri': redirectUri,
+        'client_id': clientId,
+        'code_verifier': verifier,
+      },
+    ).timeout(const Duration(seconds: 15));
+
+    if (resp.statusCode != 200) {
+      String message = 'Token exchange failed (${resp.statusCode})';
+      try {
+        final err = json.decode(resp.body) as Map<String, dynamic>;
+        final desc = err['error_description'] ?? err['error'];
+        if (desc != null) message = desc.toString();
+      } catch (_) {}
+      throw OAuthException(message, code: 'token_exchange_failed');
+    }
+
+    final data = json.decode(resp.body) as Map<String, dynamic>;
+    final token = data['access_token'] as String?;
+    if (token == null) {
+      throw OAuthException('Token response missing access_token', code: 'token_exchange_failed');
+    }
+    return OAuthResult(
+      token: token,
+      scope: data['scope'] as String?,
+      vaultName: data['vault'] as String? ?? data['vault_name'] as String?,
+    );
+  }
+
+  /// Listen for a `parachute://oauth/callback?...` deep link.
+  Future<_CallbackParams> _waitForCallback({
+    required String state,
+    required Duration timeout,
+  }) async {
+    final completer = Completer<_CallbackParams>();
+    StreamSubscription<Uri>? sub;
+    Timer? timer;
+
+    void finish(_CallbackParams params) {
+      if (completer.isCompleted) return;
+      sub?.cancel();
+      timer?.cancel();
+      completer.complete(params);
+    }
+
+    void fail(Object error) {
+      if (completer.isCompleted) return;
+      sub?.cancel();
+      timer?.cancel();
+      completer.completeError(error);
+    }
+
+    sub = _appLinks.uriLinkStream.listen(
+      (uri) {
+        if (uri.scheme != 'parachute' || uri.host != 'oauth') return;
+        if (!uri.path.startsWith('/callback')) return;
+
+        final params = uri.queryParameters;
+        final returnedState = params['state'];
+        if (returnedState != state) {
+          fail(OAuthException('State mismatch in OAuth callback', code: 'state_mismatch'));
+          return;
+        }
+        finish(_CallbackParams(
+          code: params['code'],
+          error: params['error'],
+          errorDescription: params['error_description'],
+        ));
+      },
+      onError: (e) => fail(OAuthException('Deep link error: $e', code: 'deep_link_error')),
+    );
+
+    timer = Timer(timeout, () {
+      fail(OAuthException('Timed out waiting for authorization', code: 'timeout'));
+    });
+
+    return completer.future;
+  }
+
+  String _normalizeServerUrl(String url) {
+    var u = url.trim();
+    if (u.isEmpty) throw OAuthException('Server URL is empty', code: 'invalid_url');
+    if (!u.startsWith('http://') && !u.startsWith('https://')) {
+      u = 'https://$u';
+    }
+    return u.replaceAll(RegExp(r'/+$'), '');
+  }
+
+  // PKCE helpers.
+  String _generateCodeVerifier() => _randomString(64);
+
+  String _codeChallenge(String verifier) {
+    final digest = sha256.convert(utf8.encode(verifier));
+    return base64Url.encode(digest.bytes).replaceAll('=', '');
+  }
+
+  String _randomString(int length) {
+    const charset = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~';
+    final rng = Random.secure();
+    return List.generate(length, (_) => charset[rng.nextInt(charset.length)]).join();
+  }
+
+  void dispose() {
+    _http.close();
+  }
+}
+
+class _Discovery {
+  final String authorizationEndpoint;
+  final String tokenEndpoint;
+  final String registrationEndpoint;
+  _Discovery({
+    required this.authorizationEndpoint,
+    required this.tokenEndpoint,
+    required this.registrationEndpoint,
+  });
+}
+
+class _CallbackParams {
+  final String? code;
+  final String? error;
+  final String? errorDescription;
+  _CallbackParams({this.code, this.error, this.errorDescription});
+}

--- a/lib/features/settings/widgets/server_settings_section.dart
+++ b/lib/features/settings/widgets/server_settings_section.dart
@@ -7,6 +7,7 @@ import 'package:parachute/core/providers/app_state_provider.dart'
 import 'package:parachute/core/providers/feature_flags_provider.dart';
 import 'package:parachute/core/services/backend_health_service.dart';
 import 'package:parachute/core/services/graph_api_service.dart';
+import 'package:parachute/features/settings/services/oauth_service.dart';
 
 /// Server connection settings section — vault URL, API key, vault picker.
 class ServerSettingsSection extends ConsumerStatefulWidget {
@@ -23,6 +24,8 @@ class _ServerSettingsSectionState extends ConsumerState<ServerSettingsSection> {
   List<String>? _availableVaults;
   String? _selectedVault;
   bool _loadingVaults = false;
+  bool _showManualToken = false;
+  bool _connecting = false;
 
   @override
   void initState() {
@@ -46,7 +49,10 @@ class _ServerSettingsSectionState extends ConsumerState<ServerSettingsSection> {
     if (mounted) {
       setState(() {
         _serverUrlController.text = serverUrl;
-        if (apiKey != null) _apiKeyController.text = apiKey;
+        if (apiKey != null) {
+          _apiKeyController.text = apiKey;
+          _showManualToken = true;
+        }
         _selectedVault = vaultName;
       });
 
@@ -128,6 +134,62 @@ class _ServerSettingsSectionState extends ConsumerState<ServerSettingsSection> {
           backgroundColor: BrandColors.success,
         ),
       );
+    }
+  }
+
+  Future<void> _connectOAuth() async {
+    final url = _serverUrlController.text.trim();
+    if (url.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: const Text('Enter a server URL first'),
+          backgroundColor: BrandColors.warning,
+        ),
+      );
+      return;
+    }
+
+    // Persist the URL before launching so it survives the browser round-trip.
+    await _saveServerUrl();
+
+    setState(() => _connecting = true);
+    final oauth = OAuthService();
+    try {
+      final result = await oauth.connect(serverUrl: url);
+      _apiKeyController.text = result.token;
+      await ref.read(apiKeyProvider.notifier).setApiKey(result.token);
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(result.vaultName != null
+                ? 'Connected to ${result.vaultName}'
+                : 'Connected to vault'),
+            backgroundColor: BrandColors.success,
+          ),
+        );
+        _fetchVaults(url);
+      }
+    } on OAuthException catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Connection failed: ${e.message}'),
+            backgroundColor: BrandColors.error,
+          ),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Connection failed: $e'),
+            backgroundColor: BrandColors.error,
+          ),
+        );
+      }
+    } finally {
+      oauth.dispose();
+      if (mounted) setState(() => _connecting = false);
     }
   }
 
@@ -278,25 +340,60 @@ class _ServerSettingsSectionState extends ConsumerState<ServerSettingsSection> {
         ),
         SizedBox(height: Spacing.md),
 
-        // API Key
-        TextField(
-          controller: _apiKeyController,
-          decoration: InputDecoration(
-            labelText: 'API Key',
-            hintText: 'para_... or pvk_...',
-            border: const OutlineInputBorder(),
-            prefixIcon: const Icon(Icons.key),
-            suffixIcon: IconButton(
-              icon: const Icon(Icons.clear),
-              onPressed: () {
-                _apiKeyController.clear();
-                _saveApiKey();
-              },
+        // Connect to Vault (OAuth)
+        SizedBox(
+          width: double.infinity,
+          child: FilledButton.icon(
+            onPressed: _connecting ? null : _connectOAuth,
+            icon: _connecting
+                ? const SizedBox(
+                    width: 16,
+                    height: 16,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Icon(Icons.lock_open, size: 18),
+            label: Text(_connecting ? 'Connecting...' : 'Connect to Vault'),
+            style: FilledButton.styleFrom(
+              backgroundColor: BrandColors.turquoise,
             ),
           ),
-          obscureText: true,
-          onSubmitted: (_) => _saveApiKey(),
         ),
+        SizedBox(height: Spacing.xs),
+        Align(
+          alignment: Alignment.centerRight,
+          child: TextButton(
+            onPressed: () {
+              setState(() => _showManualToken = !_showManualToken);
+            },
+            child: Text(
+              _showManualToken ? 'Hide manual token' : 'Use manual token',
+              style: const TextStyle(fontSize: 12),
+            ),
+          ),
+        ),
+
+        // API Key (manual fallback)
+        if (_showManualToken) ...[
+          SizedBox(height: Spacing.xs),
+          TextField(
+            controller: _apiKeyController,
+            decoration: InputDecoration(
+              labelText: 'API Key',
+              hintText: 'pvt_... or para_...',
+              border: const OutlineInputBorder(),
+              prefixIcon: const Icon(Icons.key),
+              suffixIcon: IconButton(
+                icon: const Icon(Icons.clear),
+                onPressed: () {
+                  _apiKeyController.clear();
+                  _saveApiKey();
+                },
+              ),
+            ),
+            obscureText: true,
+            onSubmitted: (_) => _saveApiKey(),
+          ),
+        ],
         SizedBox(height: Spacing.md),
 
         // Vault picker

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -17,6 +17,7 @@ import package_info_plus
 import path_provider_foundation
 import record_macos
 import shared_preferences_foundation
+import url_launcher_macos
 import wakelock_plus
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
@@ -32,5 +33,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   RecordMacOsPlugin.register(with: registry.registrar(forPlugin: "RecordMacOsPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
+  UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
   WakelockPlusMacosPlugin.register(with: registry.registrar(forPlugin: "WakelockPlusMacosPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1580,6 +1580,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.2"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: "3bb000251e55d4a209aa0e2e563309dc9bb2befea2295fd0cec1f51760aac572"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.29"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: "580fe5dfb51671ae38191d316e027f6b76272b026370708c2d898799750a02b0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.4.1"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: d5e14138b3bc193a0f63c10a53c94b91d399df0512b1f29b94a043db7482384a
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: "368adf46f71ad3c21b8f06614adb38346f193f3a59ba8fe9a2fd74133070ba18"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.5"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: d0412fcf4c6b31ecfdb7762359b7206ffba3bbffd396c6d9f9c4616ece476c1f
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "712c70ab1b99744ff066053cbe3e80c73332b38d46e5e945c98689b2e66fc15f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.5"
   uuid:
     dependency: transitive
     description:
@@ -1702,4 +1766,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.10.0 <4.0.0"
-  flutter: ">=3.35.0"
+  flutter: ">=3.38.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,6 +30,9 @@ dependencies:
   # Deep Links
   app_links: ^6.3.2
 
+  # External URLs (OAuth browser flow)
+  url_launcher: ^6.3.0
+
   # App Info
   package_info_plus: ^8.0.0
 


### PR DESCRIPTION
## Summary

Replaces the paste-an-API-key onboarding with a browser-based OAuth flow against the vault's new OAuth 2.1 provider. Users enter their vault URL, tap **Connect to Vault**, approve in the browser (with optional TOTP), and get redirected back to Daily via `parachute://oauth/callback` with a `pvt_` token stored in secure storage.

- `OAuthService` — pure-Dart OAuth 2.1 client with dynamic client registration, PKCE S256, and discovery via `/.well-known/oauth-authorization-server` (with `/.well-known/oauth-protected-resource` fallback).
- Settings UI — new primary **Connect to Vault** button; manual token entry kept as a collapsible fallback ("Use manual token"). Existing manual tokens stay visible for migrated users.
- Token storage unchanged — reuses `apiKeyProvider` / `FlutterSecureStorage`.
- Deep link — reuses the already-registered `parachute://` scheme, new host `oauth` with path `/callback`. No Android manifest or iOS plist changes required.
- New dependency: `url_launcher ^6.3.0` for launching the system browser.

## Implementation notes

- The OAuth service subscribes to `AppLinks().uriLinkStream` **before** calling `launchUrl` to avoid a race where a fast callback is missed.
- State is validated on the callback; timeout defaults to 5 minutes; all error paths feed a single `OAuthException` surfaced as a snackbar.
- Chose pure-Dart OAuth over `flutter_appauth` to avoid adding native iOS/Android deps when the existing `parachute://` scheme + `app_links` + `http` + `crypto` gave us everything needed.

## Test plan

- [ ] Manual smoke test against production vault at `parachute.taildf9ce2.ts.net`
- [ ] Verify TOTP prompt flows through when 2FA is enrolled
- [ ] Verify Deny / close-browser path shows the timeout error and doesn't hang
- [ ] Verify manual token fallback still works and is hidden by default for fresh users
- [ ] \`flutter analyze\` — clean (no new issues; 24 pre-existing info-level lints unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)