### PR TITLE
fix: bump transcription timeout from 60s to 10min

### DIFF
--- a/lib/core/services/transcription_api_service.dart
+++ b/lib/core/services/transcription_api_service.dart
@@ -23,7 +23,7 @@ class TranscriptionApiService {
     this.apiKey,
     this.model = 'whisper-large-v3',
     http.Client? client,
-    Duration timeout = const Duration(seconds: 60),
+    Duration timeout = const Duration(minutes: 10),
   })  : _client = client ?? http.Client(),
         _timeout = timeout;
 


### PR DESCRIPTION
Long voice memos were timing out at the client before Scribe could respond. 60s wasn't enough headroom for 5+ minute recordings on typical hardware. 10min is comfortable.