### PR TITLE
fix: voice-entry timestamps + non-blocking recorder UX

### DIFF
--- a/lib/features/daily/journal/screens/journal_screen.dart
+++ b/lib/features/daily/journal/screens/journal_screen.dart
@@ -502,6 +502,30 @@ class _JournalScreenState extends ConsumerState<JournalScreen> with WidgetsBindi
     required int duration,
     required DateTime createdAt,
   }) async {
+    try {
+      await _runVoiceEntryUpload(
+        localId: localId,
+        initialTranscript: initialTranscript,
+        localAudioPath: localAudioPath,
+        duration: duration,
+        createdAt: createdAt,
+      );
+    } catch (e, st) {
+      // The caller doesn't await us, so any uncaught throw here disappears.
+      // Log it explicitly; the pending entry stays in the queue and the user
+      // can retry via the card's Transcribe button or pending-sync retry.
+      debugPrint('[JournalScreen] Background voice finish failed: $e\n$st');
+    }
+  }
+
+  Future<void> _runVoiceEntryUpload({
+    required String localId,
+    required String initialTranscript,
+    required String localAudioPath,
+    required int duration,
+    required DateTime createdAt,
+  }) async {
+    if (!mounted) return;
     final api = ref.read(dailyApiServiceProvider);
 
     final serverPath = await api.uploadAudio(File(localAudioPath));
@@ -564,6 +588,7 @@ class _JournalScreenState extends ConsumerState<JournalScreen> with WidgetsBindi
     await api.addAttachment(entry.id, serverPath, mime);
 
     // Swap the pending entry for the server entry in cache + UI.
+    if (!mounted) return;
     final cache = await ref.read(noteLocalCacheProvider.future);
     cache.removeNote(localId);
     cache.putNotes([

--- a/lib/features/daily/journal/screens/journal_screen.dart
+++ b/lib/features/daily/journal/screens/journal_screen.dart
@@ -538,6 +538,7 @@ class _JournalScreenState extends ConsumerState<JournalScreen> with WidgetsBindi
     }
 
     // Online: try Scribe for a transcript before creating the note.
+    if (!mounted) return;
     String content = initialTranscript;
     final transcriptionService = ref.read(transcriptionApiServiceProvider);
     if (content.isEmpty && transcriptionService != null) {

--- a/lib/features/daily/journal/screens/journal_screen.dart
+++ b/lib/features/daily/journal/screens/journal_screen.dart
@@ -14,7 +14,6 @@ import 'package:parachute/core/providers/app_state_provider.dart' show apiKeyPro
 import 'package:parachute/core/providers/feature_flags_provider.dart' show aiServerUrlProvider;
 import 'package:parachute/core/providers/connectivity_provider.dart' show isServerAvailableProvider;
 import 'package:parachute/core/models/thing.dart';
-import 'package:parachute/core/services/note_local_cache.dart';
 import 'package:parachute/core/services/tag_service.dart' show TagInfo, tagServiceProvider;
 import 'package:parachute/features/vault/providers/vault_providers.dart';
 import '../../recorder/providers/post_hoc_transcription_provider.dart';
@@ -322,56 +321,6 @@ class _JournalScreenState extends ConsumerState<JournalScreen> with WidgetsBindi
 
   // ========== Entry CRUD Operations ==========
 
-  /// Adds an entry to the local cache for immediate display.
-  ///
-  /// If [entry] is null the write failed — fall back to adding a pending entry.
-  Future<void> _appendEntryToCache(JournalEntry? entry, {
-    required String content,
-    JournalEntryType type = JournalEntryType.text,
-    String? audioPath,
-    String? imagePath,
-    int? durationSeconds,
-  }) async {
-    if (entry != null) {
-      final date = ref.read(selectedJournalDateProvider);
-      setState(() {
-        _cachedJournal = (_cachedJournal ?? JournalDay.empty(date)).addEntry(entry);
-        _shouldScrollToBottom = true;
-      });
-      // Write to cache immediately so Phase 1 of the next provider load
-      // includes this entry.
-      final cache = await ref.read(noteLocalCacheProvider.future);
-      final note = Note(
-        id: entry.id,
-        content: entry.content,
-        createdAt: entry.createdAt,
-        tags: entry.tags ?? ['captured'],
-      );
-      cache.putNotes([note]);
-    } else {
-      // Offline — save to cache as pending_create
-      final cache = await ref.read(noteLocalCacheProvider.future);
-      final localId = 'pending-${DateTime.now().millisecondsSinceEpoch}';
-      final tags = <String>['captured'];
-      final pendingNote = Note(id: localId, content: content, createdAt: DateTime.now(), tags: tags);
-      cache.insertPendingCreate(pendingNote, audioPath: audioPath);
-      final pending = JournalEntry(
-        id: localId, content: content, title: '', createdAt: DateTime.now(),
-        type: type, audioPath: audioPath, isPending: true,
-        durationSeconds: durationSeconds,
-      );
-      if (!mounted) return;
-      setState(() {
-        final date = ref.read(selectedJournalDateProvider);
-        _cachedJournal = (_cachedJournal ?? JournalDay.empty(date)).addEntry(pending);
-        _shouldScrollToBottom = true;
-      });
-    }
-    if (!mounted) return;
-    ref.invalidate(selectedJournalProvider);
-    ref.read(journalRefreshTriggerProvider.notifier).state++;
-  }
-
   static String _entryTypeString(JournalEntryType type) {
     switch (type) {
       case JournalEntryType.voice: return 'voice';
@@ -474,126 +423,186 @@ class _JournalScreenState extends ConsumerState<JournalScreen> with WidgetsBindi
 
   Future<void> _addVoiceEntry(String transcript, String localAudioPath, int duration, DateTime createdAt) async {
     debugPrint('[JournalScreen] Adding voice entry (createdAt: $createdAt)...');
-    await _addVoiceEntryLocally(
-      transcript,
-      localAudioPath,
-      duration,
-      createdAt,
+
+    // Non-blocking: write a pending entry to the local cache and UI right away
+    // so the recorder stays available. Upload + transcription run in the
+    // background and upgrade the pending entry into a server entry when done.
+    final localId = 'pending-${DateTime.now().millisecondsSinceEpoch}';
+    await _insertPendingVoiceEntry(
+      localId: localId,
+      content: transcript,
+      localAudioPath: localAudioPath,
+      duration: duration,
+      createdAt: createdAt,
     );
+
+    // Intentionally not awaited — caller (JournalInputBar) can clear its
+    // processing flag as soon as the pending entry is visible.
+    unawaited(_finishVoiceEntryInBackground(
+      localId: localId,
+      initialTranscript: transcript,
+      localAudioPath: localAudioPath,
+      duration: duration,
+      createdAt: createdAt,
+    ));
   }
 
-  /// Upload audio, transcribe via Scribe, create note with content + attachment.
+  /// Insert a pending voice entry into the local cache and UI.
   ///
-  /// Transcription strategy: Scribe (server) first → on-device fallback → empty.
-  /// The note is created with whatever transcript is available so the vault
-  /// stores a fully-formed note. No vault trigger dependency.
-  Future<void> _addVoiceEntryLocally(
-    String transcript,
-    String localAudioPath,
-    int duration,
-    DateTime createdAt,
-  ) async {
+  /// The pending entry carries the local audio path so the entry card can
+  /// show its own "Transcribing..." indicator and play the audio before the
+  /// server round-trip completes.
+  Future<void> _insertPendingVoiceEntry({
+    required String localId,
+    required String content,
+    required String localAudioPath,
+    required int duration,
+    required DateTime createdAt,
+  }) async {
+    final cache = await ref.read(noteLocalCacheProvider.future);
+    final pendingNote = Note(
+      id: localId,
+      content: content,
+      createdAt: createdAt,
+      tags: const ['captured'],
+    );
+    cache.insertPendingCreate(pendingNote, audioPath: localAudioPath);
+
+    if (!mounted) return;
+    final pending = JournalEntry(
+      id: localId,
+      content: content,
+      title: '',
+      createdAt: createdAt,
+      type: JournalEntryType.voice,
+      audioPath: localAudioPath,
+      durationSeconds: duration,
+      isPending: true,
+      isPendingTranscription: content.isEmpty,
+    );
+    setState(() {
+      final date = ref.read(selectedJournalDateProvider);
+      _cachedJournal = (_cachedJournal ?? JournalDay.empty(date)).addEntry(pending);
+      _shouldScrollToBottom = true;
+    });
+    ref.read(journalRefreshTriggerProvider.notifier).state++;
+  }
+
+  /// Upload audio + transcribe + create server note, then swap the pending
+  /// entry for the authoritative server entry in cache and UI.
+  ///
+  /// Transcription strategy: Scribe (server) first → on-device fallback →
+  /// empty (user can tap the Transcribe button to retry later). If upload
+  /// fails the entry stays pending and will flush via the pending-sync queue
+  /// on reconnect.
+  Future<void> _finishVoiceEntryInBackground({
+    required String localId,
+    required String initialTranscript,
+    required String localAudioPath,
+    required int duration,
+    required DateTime createdAt,
+  }) async {
     final api = ref.read(dailyApiServiceProvider);
 
-    // Try to upload audio to server first
     final serverPath = await api.uploadAudio(File(localAudioPath));
-    if (!mounted) return;
+    if (serverPath == null) {
+      // Offline / upload failed: leave the pending entry in the cache so the
+      // pending-sync queue can flush it when the server is reachable again.
+      debugPrint(
+          '[JournalScreen] Voice upload failed — pending entry $localId stays queued');
+      return;
+    }
 
-    if (serverPath != null) {
-      // Online path: try Scribe transcription before creating the note.
-      String content = transcript; // on-device streaming transcript (may be empty)
-
-      final transcriptionService = ref.read(transcriptionApiServiceProvider);
-      if (transcriptionService != null) {
-        try {
-          debugPrint('[JournalScreen] Trying Scribe transcription...');
-          final scribeText = await transcriptionService.transcribe(localAudioPath);
-          if (scribeText.isNotEmpty) {
-            content = scribeText;
-            debugPrint('[JournalScreen] Scribe transcript: ${content.length} chars');
-          }
-        } catch (e) {
-          debugPrint('[JournalScreen] Scribe transcription failed: $e');
-          // Fall through to on-device fallback
+    // Online: try Scribe for a transcript before creating the note.
+    String content = initialTranscript;
+    final transcriptionService = ref.read(transcriptionApiServiceProvider);
+    if (content.isEmpty && transcriptionService != null) {
+      try {
+        debugPrint('[JournalScreen] Trying Scribe transcription for $localId...');
+        final scribeText = await transcriptionService.transcribe(localAudioPath);
+        if (scribeText.isNotEmpty) {
+          content = scribeText;
+          debugPrint(
+              '[JournalScreen] Scribe transcript: ${content.length} chars');
         }
+      } catch (e) {
+        debugPrint('[JournalScreen] Scribe transcription failed: $e');
+        // Fall through to creating the note with empty content; the on-device
+        // post-hoc transcription provider picks it up next.
       }
+    }
 
-      // Create entry with transcript content
-      final entry = await api.createEntry(
-        content: content,
-        createdAt: createdAt,
-        metadata: {
-          'type': 'voice',
-          'audio_path': serverPath,
-          'duration_seconds': duration,
-          'source': 'voice',
-          if (content.isEmpty) 'transcription_status': 'processing',
-        },
-      );
-      if (!mounted) return;
+    final entry = await api.createEntry(
+      content: content,
+      createdAt: createdAt,
+      metadata: {
+        'type': 'voice',
+        'audio_path': serverPath,
+        'duration_seconds': duration,
+        'source': 'voice',
+        if (content.isEmpty) 'transcription_status': 'processing',
+      },
+    );
 
-      if (entry != null) {
-        // Attach audio to the note so vault has a proper attachment record
-        final ext = serverPath.split('.').last.toLowerCase();
-        final mime = switch (ext) {
-          'ogg' || 'opus' => 'audio/ogg',
-          'wav' => 'audio/wav',
-          'mp3' => 'audio/mpeg',
-          'm4a' || 'mp4' => 'audio/mp4',
-          _ => 'audio/ogg',
-        };
-        await api.addAttachment(entry.id, serverPath, mime);
+    if (entry == null) {
+      // Upload succeeded but note creation failed — leave the pending entry
+      // in place so the pending-sync queue can retry the POST.
+      debugPrint(
+          '[JournalScreen] Note POST failed — pending entry $localId stays queued');
+      return;
+    }
 
-        await _appendEntryToCache(
-          entry,
-          content: content,
-          type: JournalEntryType.voice,
-          audioPath: serverPath,
-          durationSeconds: duration,
-        );
+    // Attach audio to the server note so vault has a proper attachment record.
+    final ext = serverPath.split('.').last.toLowerCase();
+    final mime = switch (ext) {
+      'ogg' || 'opus' => 'audio/ogg',
+      'wav' => 'audio/wav',
+      'mp3' => 'audio/mpeg',
+      'm4a' || 'mp4' => 'audio/mp4',
+      _ => 'audio/ogg',
+    };
+    await api.addAttachment(entry.id, serverPath, mime);
 
-        // If Scribe produced a transcript, we're done. Otherwise fall back
-        // to on-device post-hoc transcription.
-        if (content.isEmpty) {
-          debugPrint('[JournalScreen] No Scribe transcript — enqueuing on-device transcription for ${entry.id}');
-          ref.read(postHocTranscriptionProvider.notifier).enqueue(
-            entryId: entry.id,
-            audioPath: localAudioPath,
-            durationSeconds: duration,
-          );
-        } else {
-          // Transcript obtained — clean up local audio file
-          try {
-            await File(localAudioPath).delete();
-          } catch (e) {
-            debugPrint('[JournalScreen] Failed to delete staged audio: $e');
-          }
-        }
-      } else {
-        // Upload succeeded but entry creation failed — queue with server path
-        await _appendEntryToCache(
-          null,
-          content: content,
-          type: JournalEntryType.voice,
-          audioPath: serverPath,
-          durationSeconds: duration,
-        );
-        try {
-          await File(localAudioPath).delete();
-        } catch (e) {
-          debugPrint('[JournalScreen] Failed to delete staged audio: $e');
-        }
+    // Swap the pending entry for the server entry in cache + UI.
+    final cache = await ref.read(noteLocalCacheProvider.future);
+    cache.removeNote(localId);
+    cache.putNotes([
+      Note(
+        id: entry.id,
+        content: entry.content,
+        createdAt: entry.createdAt,
+        tags: entry.tags ?? const ['captured'],
+      ),
+    ]);
+
+    if (mounted) {
+      setState(() {
+        _cachedJournal = _cachedJournal
+            ?.removeEntry(localId)
+            .addEntry(entry);
+      });
+      ref.invalidate(selectedJournalProvider);
+      ref.read(journalRefreshTriggerProvider.notifier).state++;
+    }
+
+    if (content.isEmpty) {
+      // Scribe returned nothing — fall back to on-device post-hoc transcription.
+      debugPrint(
+          '[JournalScreen] No Scribe transcript — enqueuing on-device transcription for ${entry.id}');
+      if (mounted) {
+        ref.read(postHocTranscriptionProvider.notifier).enqueue(
+              entryId: entry.id,
+              audioPath: localAudioPath,
+              durationSeconds: duration,
+            );
       }
     } else {
-      // Offline: save with staged local path — will upload on reconnect
-      debugPrint('[JournalScreen] Offline — voice entry queued with staged audio');
-      await _appendEntryToCache(
-        null,
-        content: transcript,
-        type: JournalEntryType.voice,
-        audioPath: localAudioPath,
-        durationSeconds: duration,
-      );
+      // Transcript obtained — clean up local audio file.
+      try {
+        await File(localAudioPath).delete();
+      } catch (e) {
+        debugPrint('[JournalScreen] Failed to delete staged audio: $e');
+      }
     }
   }
 

--- a/lib/features/daily/journal/services/daily_api_service.dart
+++ b/lib/features/daily/journal/services/daily_api_service.dart
@@ -139,7 +139,10 @@ class DailyApiService {
       final body = jsonEncode({
         'content': content,
         'tags': tags,
-        if (createdAt != null) 'created_at': createdAt.toIso8601String(),
+        // Always send UTC with a `Z` suffix. A local `DateTime.toIso8601String()`
+        // emits a bare timestamp (no offset), which the server interprets as UTC
+        // and shifts by the user's offset.
+        if (createdAt != null) 'created_at': formatCreatedAt(createdAt),
       });
       final response = await _client
           .post(uri, headers: _headers, body: body)
@@ -477,6 +480,14 @@ String nextDate(String date) {
   final d = next.day.toString().padLeft(2, '0');
   return '$y-$m-$d';
 }
+
+/// Serialize a [DateTime] as a UTC ISO 8601 string (`Z`-suffixed).
+///
+/// The vault server treats bare timestamps (no offset or `Z`) as UTC, so a
+/// local `DateTime.toIso8601String()` — which has no suffix — would cause
+/// times to shift by the user's offset. Always route server-bound timestamps
+/// through this helper.
+String formatCreatedAt(DateTime dt) => dt.toUtc().toIso8601String();
 
 /// Parse a YYYY-MM-DD string as local midnight.
 ///

--- a/lib/features/daily/journal/widgets/journal_input_bar.dart
+++ b/lib/features/daily/journal/widgets/journal_input_bar.dart
@@ -288,7 +288,9 @@ class _JournalInputBarState extends ConsumerState<JournalInputBar>
 
     try {
       // Capture recording start time before stopping (stop resets state)
-      final createdAt = ref.read(dailyRecordingProvider).startedAt ?? DateTime.now();
+      // Fallback must be UTC too — a bare local DateTime would reintroduce
+      // the timezone-shift bug if `startedAt` is ever null.
+      final createdAt = ref.read(dailyRecordingProvider).startedAt ?? DateTime.now().toUtc();
 
       final dailyNotifier = ref.read(dailyRecordingProvider.notifier);
       final audioPath = await dailyNotifier.stopRecording();

--- a/lib/features/daily/recorder/providers/daily_recording_provider.dart
+++ b/lib/features/daily/recorder/providers/daily_recording_provider.dart
@@ -77,7 +77,10 @@ class DailyRecordingNotifier extends StateNotifier<DailyRecordingState> {
         isRecording: true,
         duration: Duration.zero,
         audioPath: null,
-        startedAt: DateTime.now(),
+        // Capture in UTC so it serializes with a `Z` suffix when sent to the
+        // vault. Local DateTimes emit a bare timestamp, which the server
+        // interprets as UTC and shifts by the user's offset.
+        startedAt: DateTime.now().toUtc(),
       );
 
       _startDurationTimer();

--- a/test/daily_api_service_timestamp_test.dart
+++ b/test/daily_api_service_timestamp_test.dart
@@ -1,0 +1,48 @@
+// Tests for server-bound timestamp serialization. Regression coverage for a
+// bug where voice entries landed in the vault with `createdAt` shifted by the
+// user's timezone offset: the app sent a local `DateTime.toIso8601String()`
+// (no `Z` or offset suffix) and the server treated the bare timestamp as UTC.
+//
+// Run with: flutter test test/daily_api_service_timestamp_test.dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:parachute/features/daily/journal/services/daily_api_service.dart';
+
+void main() {
+  group('formatCreatedAt', () {
+    test('emits a Z-suffixed UTC ISO string for a UTC DateTime', () {
+      final utc = DateTime.utc(2026, 4, 15, 16, 30, 0);
+      expect(formatCreatedAt(utc), '2026-04-15T16:30:00.000Z');
+    });
+
+    test('converts a local DateTime to the same instant in UTC', () {
+      // Build a local wall-clock time, then check the serialized value
+      // represents the same instant (not the same wall-clock digits).
+      final local = DateTime(2026, 4, 15, 10, 30, 0);
+      final serialized = formatCreatedAt(local);
+
+      expect(serialized.endsWith('Z'), isTrue,
+          reason: 'server-bound timestamps must be Z-suffixed');
+
+      final parsed = DateTime.parse(serialized);
+      expect(parsed.isUtc, isTrue);
+      expect(parsed.millisecondsSinceEpoch,
+          local.millisecondsSinceEpoch,
+          reason: 'conversion must preserve the instant');
+    });
+
+    test('is idempotent for already-UTC input', () {
+      final utc = DateTime.utc(2026, 4, 15, 16, 30, 0);
+      expect(formatCreatedAt(utc), formatCreatedAt(utc.toUtc()));
+    });
+
+    test('regression: bare local toIso8601String would NOT be Z-suffixed', () {
+      // Documents the bug this helper guards against: the raw
+      // `toIso8601String()` on a local DateTime produces a bare timestamp
+      // (no `Z`, no offset), which the vault server misinterprets as UTC.
+      final local = DateTime(2026, 4, 15, 10, 30, 0);
+      expect(local.toIso8601String().endsWith('Z'), isFalse);
+      // The helper always produces a Z-suffixed value.
+      expect(formatCreatedAt(local).endsWith('Z'), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Two bugs in the voice-capture flow, fixed together because both live in `_addVoiceEntryLocally`:

1. **Wrong `createdAt` on voice notes.** Recorder captured `DateTime.now()` (local); API service called `toIso8601String()` on the local value, producing a bare timestamp with no offset/`Z`. Per #97 the vault server treats bare timestamps as UTC, so times shifted by the user's offset. Typed entries were fixed in #88; voice was missed.
2. **Recorder blocked during transcription.** `_addVoiceEntryLocally` awaited `uploadAudio → Scribe transcribe → createEntry` before writing the pending note to the UI, leaving `JournalInputBar._isProcessing` true — up to the 10-min Scribe timeout (#103) — which disabled the mic, expand, and send buttons.

## Changes

- **Commit 1 — timestamps**: capture `startedAt` in UTC at the recorder; add `formatCreatedAt(DateTime)` helper in `daily_api_service.dart` that always produces a `Z`-suffixed UTC string; route `createNote` through it. Unit test covers UTC-in, local-in, idempotence, and the bare-`toIso8601String` regression.
- **Commit 2 — non-blocking flow**: `_addVoiceEntry` now (a) writes a pending voice entry to cache + UI immediately, (b) returns so `JournalInputBar` clears its processing flag, (c) runs upload + Scribe + `createEntry` in an unawaited background future that swaps the pending entry for the server entry when done. On failure the pending entry stays queued and the existing pending-sync retry flushes it — mirrors the typed-entry pattern. The per-note "Transcribing…" spinner and audio chip already exist via `isPendingTranscription`.
- **Commit 3 — hardening**: review-pass feedback. Wrap the background future in `try/catch` + `debugPrint`, add `!mounted` guards before provider reads.

## Known follow-up (out of scope)

- Pending entries lose their `isPending` flag on reload because `_noteToEntry` doesn't consult `sync_state`. Pre-existing — typed entries have the same issue. Filing separately.
- App-kill resilience: an entry stuck in `transcription_status: processing` after the app is killed mid-flight has no auto-retry on next launch. Filing separately.

## Test plan

- [x] `flutter test test/daily_api_service_timestamp_test.dart` — 4 new tests pass
- [x] `flutter analyze` — no new warnings (3 pre-existing infos in the file; count unchanged)
- [ ] Manual: record a voice note, start a second recording immediately while the first transcribes — both should succeed without blocking
- [ ] Manual: record a voice note and confirm its vault `created_at` matches the local wall clock
- [ ] Manual: record while offline; reconnect; confirm pending-sync flushes the audio and note

🤖 Generated with [Claude Code](https://claude.com/claude-code)