### PR TITLE
fix: guard audio deletion and bump scribe timeout

### DIFF
--- a/lib/core/services/transcription_api_service.dart
+++ b/lib/core/services/transcription_api_service.dart
@@ -23,7 +23,7 @@ class TranscriptionApiService {
     this.apiKey,
     this.model = 'whisper-large-v3',
     http.Client? client,
-    Duration timeout = const Duration(minutes: 10),
+    Duration timeout = const Duration(minutes: 30),
   })  : _client = client ?? http.Client(),
         _timeout = timeout;
 

--- a/lib/features/daily/recorder/providers/post_hoc_transcription_provider.dart
+++ b/lib/features/daily/recorder/providers/post_hoc_transcription_provider.dart
@@ -269,17 +269,27 @@ class PostHocTranscriptionNotifier extends StateNotifier<PostHocTranscriptionSta
       _service?.dispose();
       _service = null;
 
-      // Clean up the staged audio file regardless of outcome. Safe because
-      // the server has its own copy (uploadAudio stored it before
-      // enqueue) — manual re-transcribe can pull the audio back from the
-      // server if the user wants to retry after a permanent failure. Only
-      // the crash-recovery path may leave files behind; `restartIncompleteJobs`
-      // already handles missing-file cases gracefully.
+      // Only delete the staged audio file if the server entry has confirmed
+      // non-empty content. If the update failed or transcription was empty,
+      // keep the local file so crash-recovery / manual retry can use it.
       try {
         final staged = File(audioPath);
         if (await staged.exists()) {
-          await staged.delete();
-          debugPrint('[PostHocTranscription] Cleaned up staged audio: $audioPath');
+          bool safeToDelete = false;
+          try {
+            final api = _ref.read(dailyApiServiceProvider);
+            final serverEntry = await api.getEntry(entryId);
+            safeToDelete = serverEntry != null && serverEntry.content.trim().isNotEmpty;
+          } catch (e) {
+            debugPrint('[PostHocTranscription] Could not verify server content, keeping audio: $e');
+          }
+
+          if (safeToDelete) {
+            await staged.delete();
+            debugPrint('[PostHocTranscription] Cleaned up staged audio: $audioPath');
+          } else {
+            debugPrint('[PostHocTranscription] Keeping staged audio (server content empty or unreachable): $audioPath');
+          }
         }
       } catch (e) {
         debugPrint('[PostHocTranscription] Failed to clean up staged audio: $e');


### PR DESCRIPTION
## Summary

- **Guard audio deletion**: The `finally` block in `PostHocTranscriptionNotifier._processJob()` now checks the server entry for non-empty content before deleting the local audio file. If the server update failed or content is empty, the audio is preserved for crash-recovery / manual retry.
- **Bump Scribe timeout**: Increased from 10 minutes to 30 minutes so 8+ minute recordings don't hit a marginal timeout under server load.

## Context

An ~8 minute voice memo was lost because Scribe timed out (10 min for 8 min audio), the error was caught silently, an empty note was created, and the finally block deleted the local audio unconditionally — making the recording unrecoverable.

## Test plan

- [ ] Record a short voice memo → verify transcription completes and local audio is cleaned up
- [ ] Simulate Scribe failure (e.g. disconnect server) → verify local audio file is NOT deleted
- [ ] Simulate `updateEntry` failure after successful transcription → verify local audio is preserved
- [ ] Restart app after failed transcription → verify `restartIncompleteJobs` picks up the preserved audio

🤖 Generated with [Claude Code](https://claude.com/claude-code)