### PR TITLE
fix(macos): add keychain-access-groups entitlement

### DIFF
--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -16,5 +16,9 @@
 	<true/>
 	<key>com.apple.security.device.audio-input</key>
 	<true/>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)io.openparachute.parachute</string>
+	</array>
 </dict>
 </plist>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -12,5 +12,9 @@
 	<true/>
 	<key>com.apple.security.device.audio-input</key>
 	<true/>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)io.openparachute.parachute</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- Adds `keychain-access-groups` entitlement to both `DebugProfile.entitlements` and `Release.entitlements`, scoped to the Runner bundle ID `io.openparachute.parachute`.
- Fixes `-34018` `errSecMissingEntitlement` raised by macOS Keychain when `flutter_secure_storage` tries to persist the `pvt_` OAuth token after completion. Without the entitlement, OAuth finishes but the token never lands in secure storage, leaving the app stuck on the connection screen.

## What was there
App Sandbox is already disabled in both files (`com.apple.security.app-sandbox = false`). Existing entitlements (network, user-selected files, bookmarks, audio-input) are untouched. `flutter_secure_storage_macos` still requires this keychain access group entitlement even when sandboxing is off.

## Bundle ID
Verified from `macos/Runner/Configs/AppInfo.xcconfig`: `PRODUCT_BUNDLE_IDENTIFIER = io.openparachute.parachute`. (The task prompt mentioned `computer.parachute.daily` as a tentative value; the Xcode project uses the `io.openparachute.parachute` identifier, so the entitlement is scoped to that.)

## Test plan
- [x] `flutter analyze` — clean (only pre-existing info-level lints, none introduced)
- [x] `flutter test` — all tests pass
- [ ] **Manual verification needed (Aaron):** `flutter run -d macos`, complete OAuth against a vault, confirm the app moves past OAuth into the connected state and a keychain entry for `io.openparachute.parachute` appears in Keychain Access.app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)